### PR TITLE
upload processed files with correct access permissions

### DIFF
--- a/documentcloud/common/environment/local/storage.py
+++ b/documentcloud/common/environment/local/storage.py
@@ -51,10 +51,12 @@ class LocalStorage:
     def size(filename):
         return os.path.getsize(os.path.join(settings.MEDIA_ROOT, filename))
 
-    def open(self, filename, mode="w"):
+    def open(self, filename, mode="w", content_type=None, access=None):
+        # pylint: disable=unused-argument
         return LocalStorageFile(self, filename, mode)
 
-    def simple_upload(self, filename, contents):
+    def simple_upload(self, filename, contents, content_type=None, access=None):
+        # pylint: disable=unused-argument
         with self.open(filename, "wb") as local_file:
             local_file.write(contents)
 

--- a/documentcloud/common/serverless/utils.py
+++ b/documentcloud/common/serverless/utils.py
@@ -29,6 +29,9 @@ REDIS_SOCKET_TIMEOUT = env.int("REDIS_SOCKET_TIMEOUT", default=10)
 REDIS_SOCKET_CONNECT_TIMEOUT = env.int("REDIS_SOCKET_CONNECT_TIMEOUT", default=10)
 REDIS_HEALTH_CHECK_INTERVAL = env.int("REDIS_HEALTH_CHECK_INTERVAL", default=10)
 
+# do not have access to DjangoChoices on serverless, so just define some constants here
+PUBLIC, ORGANIZATION, PRIVATE, INVISIBLE = 0, 1, 2, 3
+
 
 def get_redis():
     """Opens a connection to Redis and returns it"""

--- a/documentcloud/documents/processing/info_and_image/pdfium.py
+++ b/documentcloud/documents/processing/info_and_image/pdfium.py
@@ -133,11 +133,11 @@ class Bitmap:
         img = PIL.Image.merge("RGB", (r, g, b))
         return img
 
-    def render(self, storage, filename, image_format="gif"):
+    def render(self, storage, filename, access, image_format="gif"):
         img = self.get_image()
         mem_file = io.BytesIO()
         img.save(mem_file, format=image_format)
-        storage.simple_upload(filename, mem_file.getvalue())
+        storage.simple_upload(filename, mem_file.getvalue(), access=access)
         return img
 
 
@@ -290,8 +290,8 @@ class Document:
             self._monospace = self.load_font_from_file("courier.ttf")
         return self._monospace
 
-    def save(self, storage, filename):
-        with storage.open(filename, "wb") as doc_file:
+    def save(self, storage, filename, access):
+        with storage.open(filename, "wb", access=access) as doc_file:
 
             @CFUNCTYPE(c_int, c_void_p, c_void_p, c_ulong)
             def write_block(_fpdf_filewrite, p_data, size):

--- a/documentcloud/documents/processing/tests/pipeline_tests/mocks.py
+++ b/documentcloud/documents/processing/tests/pipeline_tests/mocks.py
@@ -163,7 +163,7 @@ class StorageOpen:
 files_cached = {}
 
 
-def write_cache(filename, cache):
+def write_cache(filename, cache, access):
     files_cached[filename] = cache
     cache_written(filename, cache)
 
@@ -176,7 +176,7 @@ def read_cache(filename):
         raise KeyError("Cache file not found")
 
 
-def extract_single_page(doc_id, slug, page, page_number, large_image_path):
+def extract_single_page(doc_id, slug, access, page, page_number, large_image_path):
     page_extracted(page_number)
     return (100, 200)  # Arbitrary width / height
 
@@ -189,11 +189,11 @@ def ocr_page(page_path):
     page_ocrd(page_path)
 
 
-def write_text_file(text_path, text):
+def write_text_file(text_path, text, access):
     text_file_written(text_path, text)
 
 
-def redact_doc(doc_id, slug, redactions):
+def redact_doc(doc_id, slug, access, redactions):
     """Redact document by ensuring redacted pages need OCR"""
     pages = [r["page_number"] for r in redactions]
     docs[path.doc_path(doc_id, slug)].redact(pages)

--- a/documentcloud/documents/processing/tests/pipeline_tests/test_pipeline.py
+++ b/documentcloud/documents/processing/tests/pipeline_tests/test_pipeline.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 
 # DocumentCloud
 from documentcloud.common.environment import encode_pubsub_data, publisher
+from documentcloud.documents.choices import Access
 from documentcloud.documents.processing.info_and_image.main import (
     PDF_PROCESS_TOPIC,
     REDACT_TOPIC,
@@ -19,7 +20,8 @@ from documentcloud.documents.processing.tests.pipeline_tests.mocks import (
 def trigger_processing():
     """Triggers PDF processing via pubsub."""
     publisher.publish(
-        PDF_PROCESS_TOPIC, encode_pubsub_data({"doc_id": ID, "slug": SLUG})
+        PDF_PROCESS_TOPIC,
+        encode_pubsub_data({"doc_id": ID, "slug": SLUG, "access": Access.private}),
     )
 
 
@@ -31,6 +33,7 @@ def trigger_redacting(page_numbers):
             {
                 "doc_id": ID,
                 "slug": SLUG,
+                "access": Access.private,
                 "redactions": [
                     {"page_number": page_number} for page_number in page_numbers
                 ],

--- a/documentcloud/documents/processing/tests/test_pdf_processor.py
+++ b/documentcloud/documents/processing/tests/test_pdf_processor.py
@@ -4,6 +4,7 @@ import tempfile
 
 # DocumentCloud
 from documentcloud.common.environment.local.storage import storage
+from documentcloud.documents.choices import Access
 from documentcloud.documents.processing.info_and_image.pdfium import (
     StorageHandler,
     Workspace,
@@ -42,7 +43,7 @@ class PDFProcessorTest(ReportTestCase):
                     new_fn = "doc_3_pg{}.png".format(i)
                     new_path = os.path.join(directory, new_fn)
                     bmp = page.get_bitmap(1000, None)
-                    bmp.render(storage, new_path, "png")
+                    bmp.render(storage, new_path, Access.private, "png")
                     expected_image = os.path.join(pdfs, new_fn)
                     # Assert correct extracted images.
                     self.assertTrue(

--- a/documentcloud/documents/tests/test_views.py
+++ b/documentcloud/documents/tests/test_views.py
@@ -1283,7 +1283,9 @@ class TestRedactionAPI:
             f"/api/documents/{document.pk}/redactions/", data, format="json"
         )
         assert response.status_code == status.HTTP_201_CREATED
-        mock_redact.delay.assert_called_once_with(document.pk, document.slug, data)
+        mock_redact.delay.assert_called_once_with(
+            document.pk, document.slug, document.access, data
+        )
 
     def test_create_anonymous(self, client):
         """You cannot create redactions if you are not logged in"""


### PR DESCRIPTION
Close #61 

Main thing is threading the access through all the processing calls so it knows what access to use - getting a little unwieldy with doc_id, slug and access - could group these together into some sort of data structure to pass around together - which would help if we need to add more to it in the future.  I implemented it in the simple way for now.

Also, the pipeline tests are both extremely fragile, as all of the mocks need to match the implementation, so changing their arguments breaks them, as well as difficult to debug, as the error handling swallows the errors.  Finding a way to expose the errors during failed tests would be a good start, and having the mocks automatically copy there target would be nice as well.