### PR TITLE
add endpoint to get all pending documents progress

### DIFF
--- a/documentcloud/documents/processing/utils/main.py
+++ b/documentcloud/documents/processing/utils/main.py
@@ -117,12 +117,15 @@ def get_progress(request, _context=None):
         for doc_id in doc_ids:
             redis_progress_fields.append(redis_fields.images_remaining(doc_id))
             redis_progress_fields.append(redis_fields.texts_remaining(doc_id))
+            redis_progress_fields.append(redis_fields.page_count(doc_id))
         data = grouper(
             (int(i) if i is not None else i for i in REDIS.mget(redis_progress_fields)),
-            2,
+            3,
         )
-        for doc_id, (images, texts) in zip(doc_ids, data):
-            response.append({"doc_id": doc_id, "images": images, "texts": texts})
+        for doc_id, (images, texts, pages) in zip(doc_ids, data):
+            response.append(
+                {"doc_id": doc_id, "images": images, "texts": texts, "pages": pages}
+            )
     except RedisError as exc:
         logger.error("RedisError during get_progress: %s", exc, exc_info=sys.exc_info())
         response = [

--- a/documentcloud/documents/processing/utils/main.py
+++ b/documentcloud/documents/processing/utils/main.py
@@ -106,7 +106,8 @@ def get_progress(request, _context=None):
     doc_id = data.get("doc_id")
     doc_ids = data.get("doc_ids")
 
-    if not doc_ids:
+    # doc_ids could still be specified as empty list, so check for None
+    if doc_ids is None:
         doc_ids = [doc_id]
 
     response = []

--- a/documentcloud/documents/serializers.py
+++ b/documentcloud/documents/serializers.py
@@ -271,7 +271,7 @@ class DocumentSerializer(FlexFieldsModelSerializer):
 
     def get_remaining(self, obj):
         """Get the progress data from the serverless function"""
-        # XXX remove this
+        # remove this
         try:
             response = httpsub.post(
                 settings.PROGRESS_URL,

--- a/documentcloud/documents/serializers.py
+++ b/documentcloud/documents/serializers.py
@@ -271,6 +271,7 @@ class DocumentSerializer(FlexFieldsModelSerializer):
 
     def get_remaining(self, obj):
         """Get the progress data from the serverless function"""
+        # XXX remove this
         try:
             response = httpsub.post(
                 settings.PROGRESS_URL,
@@ -278,7 +279,7 @@ class DocumentSerializer(FlexFieldsModelSerializer):
                 timeout=settings.PROGRESS_TIMEOUT,
             )
             response.raise_for_status()
-            return response.json()
+            return response.json()[0]
         except RequestException as exc:
             logger.warning(
                 "Error getting progress for document %d, exception %s",

--- a/documentcloud/documents/views.py
+++ b/documentcloud/documents/views.py
@@ -20,10 +20,11 @@ from functools import lru_cache
 import django_filters
 import environ
 import pysolr
+from requests.exceptions import RequestException
 from rest_flex_fields import FlexFieldsModelViewSet
 
 # DocumentCloud
-from documentcloud.common.environment import storage
+from documentcloud.common.environment import httpsub, storage
 from documentcloud.core.choices import Language
 from documentcloud.core.filters import ChoicesFilter, ModelMultipleChoiceFilter
 from documentcloud.core.permissions import (
@@ -400,6 +401,26 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
             )
         else:
             return Response(results.highlighting.get(pk, {}))
+
+    @action(detail=False, methods=["get"])
+    def pending(self, request):
+        """Get the progress status on all of the current users pending documents"""
+        pending_documents = list(
+            self.queryset.filter(status=Status.pending).values_list("id", flat=True)
+        )
+        try:
+            response = httpsub.post(
+                settings.PROGRESS_URL,
+                json={"doc_ids": pending_documents},
+                timeout=settings.PROGRESS_TIMEOUT,
+            )
+            response.raise_for_status()
+            return Response(response.json())
+        except RequestException as exc:
+            logger.warning(
+                "Error getting progress exception %s", exc, exc_info=sys.exc_info()
+            )
+            return Response([])
 
     class Filter(django_filters.FilterSet):
         ordering = django_filters.OrderingFilter(

--- a/documentcloud/documents/views.py
+++ b/documentcloud/documents/views.py
@@ -406,7 +406,9 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
     def pending(self, request):
         """Get the progress status on all of the current users pending documents"""
         pending_documents = list(
-            self.queryset.filter(status=Status.pending).values_list("id", flat=True)
+            self.get_queryset()
+            .filter(status=Status.pending)
+            .values_list("id", flat=True)
         )
         try:
             response = httpsub.post(


### PR DESCRIPTION
Updates the lambda function to accept multiple IDs

Adds a custom endpoint to fetch progress information on all pending documents

Once the frontend is updated all progress remaining information can be removed from the serializer