### PR TITLE
Update tasks.py to use docker<space>compose

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,7 +1,7 @@
 # Third Party
 from invoke import task
 
-COMPOSE_PREFIX = "docker-compose -f local.yml"
+COMPOSE_PREFIX = "docker compose -f local.yml"
 COMPOSE_BUILD = f"{COMPOSE_PREFIX} build {{opt}} {{service}}"
 COMPOSE_RUN_OPT = f"{COMPOSE_PREFIX} run {{opt}} --rm {{service}} {{cmd}}"
 COMPOSE_RUN_OPT_USER = COMPOSE_RUN_OPT.format(


### PR DESCRIPTION
Update tasks.py to use docker<space>compose because docker<dash>compose is deprecated. `docker-compose` is thus difficult (impossible?) to update now, and if you have a `docker-compose` too old to run the local.yaml, you're in a tough spot.