### PR TITLE
Addon api

### DIFF
--- a/documentcloud/addons/models.py
+++ b/documentcloud/addons/models.py
@@ -210,7 +210,7 @@ class AddOn(models.Model):
             self.error = False
             if "description" in self.parameters:
                 self.parameters["description"] = self._render_markdown(
-                    self.pramaters["description"]
+                    self.parameters["description"]
                 )
         except yaml.YAMLError:
             self.error = True

--- a/documentcloud/addons/views.py
+++ b/documentcloud/addons/views.py
@@ -101,6 +101,11 @@ class AddOnViewSet(viewsets.ModelViewSet):
     class Filter(django_filters.FilterSet):
         active = django_filters.BooleanFilter(field_name="active", label="Active")
         query = django_filters.CharFilter(method="query_filter", label="Query")
+        category = django_filters.CharFilter(
+            field_name="parameters",
+            lookup_expr="categories__contains",
+            label="Category",
+        )
 
         def query_filter(self, queryset, name, value):
             # pylint: disable=unused-argument

--- a/documentcloud/addons/views.py
+++ b/documentcloud/addons/views.py
@@ -52,6 +52,7 @@ from documentcloud.addons.serializers import (
 )
 from documentcloud.addons.tasks import cancel, dispatch, update_config
 from documentcloud.common.environment import storage
+from documentcloud.core.filters import QueryArrayWidget
 
 logger = logging.getLogger(__name__)
 
@@ -101,10 +102,20 @@ class AddOnViewSet(viewsets.ModelViewSet):
     class Filter(django_filters.FilterSet):
         active = django_filters.BooleanFilter(field_name="active", label="Active")
         query = django_filters.CharFilter(method="query_filter", label="Query")
-        category = django_filters.CharFilter(
+        category = django_filters.MultipleChoiceFilter(
             field_name="parameters",
             lookup_expr="categories__contains",
             label="Category",
+            widget=QueryArrayWidget,
+            choices=(
+                ("export", "export"),
+                ("ai", "ai"),
+                ("bulk", "bulk"),
+                ("extraction", "extraction"),
+                ("file", "file"),
+                ("monitor", "monitor"),
+                ("statistical", "statistical"),
+            ),
         )
 
         def query_filter(self, queryset, name, value):
@@ -112,6 +123,15 @@ class AddOnViewSet(viewsets.ModelViewSet):
             return queryset.filter(
                 Q(name__icontains=value) | Q(parameters__description__icontains=value)
             )
+
+        def category_filter(self, queryset, name, value):
+            # pylint: disable=unused-argument
+            print(repr(value))
+            print(type(value))
+            query = Q()
+            for value_ in value:
+                query |= Q(parameters__categories__contains=value_)
+            return queryset.filter(query)
 
         class Meta:
             model = AddOn

--- a/documentcloud/core/filters.py
+++ b/documentcloud/core/filters.py
@@ -56,6 +56,7 @@ class QueryArrayWidget(django_filters.widgets.BaseCSVWidget, forms.TextInput):
         else:
             ret = []
 
+        print("ret", repr(ret))
         return list(set(ret))
 
 

--- a/documentcloud/users/querysets.py
+++ b/documentcloud/users/querysets.py
@@ -69,6 +69,13 @@ class UserQuerySet(models.QuerySet):
                 queryset=Organization.objects.filter(verified_journalist=True),
                 to_attr="verified_organizations",
             ),
+            Prefetch(
+                "organizations",
+                queryset=Organization.objects.filter(
+                    memberships__admin=True
+                ).distinct(),
+                to_attr="admin_organizations",
+            ),
         )
 
         return queryset

--- a/documentcloud/users/serializers.py
+++ b/documentcloud/users/serializers.py
@@ -22,6 +22,9 @@ class UserSerializer(FlexFieldsModelSerializer):
     verified_journalist = serializers.SerializerMethodField(
         source="verified_organizations"
     )
+    admin_organizations = serializers.SerializerMethodField(
+        source="admin_organizations"
+    )
 
     class Meta:
         model = User
@@ -33,6 +36,7 @@ class UserSerializer(FlexFieldsModelSerializer):
             "name",
             "organization",
             "organizations",
+            "admin_organizations",
             "username",
             "uuid",
             "verified_journalist",
@@ -79,6 +83,15 @@ class UserSerializer(FlexFieldsModelSerializer):
             return bool(obj.verified_organizations)
         else:
             return obj.verified_journalist
+
+    def get_admin_organizations(self, obj):
+        """The organizations this user is an admin of"""
+        # If doing a list of users, we preload the admin organizations
+        # in order to avoid n+1 queries.
+        if hasattr(obj, "admin_organizations"):
+            return [o.pk for o in obj.admin_organizations]
+        else:
+            return [o.pk for o in obj.organizations.filter(memberships__admin=True)]
 
 
 class MessageSerializer(serializers.Serializer):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,6 +14,7 @@ unidecode
 markdown
 html2text
 jsonschema
+bleach
 
 # Django
 # ------------------------------------------------------------------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,6 +34,8 @@ backcall==0.1.0
     # via ipython
 billiard==3.6.3.0
     # via celery
+bleach==6.0.0
+    # via -r requirements/base.in
 boto==2.49.0
     # via smart-open
 boto3==1.21.21
@@ -381,6 +383,7 @@ six==1.15.0
     # via
     #   argon2-cffi
     #   asttokens
+    #   bleach
     #   django-appconf
     #   django-choices
     #   django-compressor
@@ -439,6 +442,8 @@ wand==0.6.6
     # via pdfplumber
 wcwidth==0.1.8
     # via prompt-toolkit
+webencodings==0.5.1
+    # via bleach
 wrapt==1.11.2
     # via
     #   -r requirements/base.in

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -70,6 +70,8 @@ billiard==3.6.3.0
     #   celery
 black==22.6.0
     # via -r requirements/local.in
+bleach==6.0.0
+    # via -r requirements/./base.txt
 boto==2.49.0
     # via
     #   -r requirements/./base.txt
@@ -646,6 +648,7 @@ six==1.15.0
     #   -r requirements/./base.txt
     #   argon2-cffi
     #   asttokens
+    #   bleach
     #   django-appconf
     #   django-choices
     #   django-compressor
@@ -760,6 +763,10 @@ wcwidth==0.1.8
     # via
     #   -r requirements/./base.txt
     #   prompt-toolkit
+webencodings==0.5.1
+    # via
+    #   -r requirements/./base.txt
+    #   bleach
 werkzeug==2.1.2
     # via -r requirements/local.in
 wrapt==1.11.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -60,6 +60,8 @@ billiard==3.6.3.0
     # via
     #   -r requirements/./base.txt
     #   celery
+bleach==6.0.0
+    # via -r requirements/./base.txt
 boto==2.49.0
     # via
     #   -r requirements/./base.txt
@@ -578,6 +580,7 @@ six==1.15.0
     #   apscheduler
     #   argon2-cffi
     #   asttokens
+    #   bleach
     #   django-anymail
     #   django-appconf
     #   django-choices
@@ -661,6 +664,10 @@ wcwidth==0.1.8
     # via
     #   -r requirements/./base.txt
     #   prompt-toolkit
+webencodings==0.5.1
+    # via
+    #   -r requirements/./base.txt
+    #   bleach
 wrapt==1.11.2
     # via
     #   -r requirements/./base.txt


### PR DESCRIPTION
* Adds a filter on categories.  Expects a categories key in the top level of the config, with a list of categories as strings.  It is not enforcing a set of approved categories at the moment.
* Renders markdown description to HTML in place on config update.  Doing it in place means we would need to manually update all add-ons on deploy (not a big deal, just need to remember to do it), as well as update the frontend and backend in sync.