### PR TITLE
Edits/Updates to API documentation...

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -141,9 +141,12 @@ registered accounts, although this may change in the future.
 Authentication happens at the MuckRock accounts server located at
 <https://accounts.muckrock.com/>. The API provided there will supply you with
 a [JWT][1] access token and refresh token in exchange for your username and
-password. The access token should be placed in the `Authorization` header
-preceded by `Bearer` - `{'Authorization': 'Bearer <access token>'}`. The
-access token is valid for 5 minutes, after which you will receive a 403
+password.
+
+The access token should be placed in the `Authorization` header
+preceded by `Token`. For example: `{'Authorization': 'Token <access token>'}`.
+
+The access token is valid for 5 minutes, after which you will receive a 403
 forbidden error if you continue trying to use it. At this point you may use
 the refresh token to obtain a new access token and refresh token. The refresh
 token is valid for one day.

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -139,7 +139,10 @@ registered accounts, although this may change in the future.
 ## Authentication
 
 Authentication happens at the MuckRock accounts server located at
-<https://accounts.muckrock.com/>. The API provided there will supply you with
+<https://accounts.muckrock.com/>. 
+
+To obtain an API key, go to your MuckRock profile and scroll to the
+bottom left-hand side. The API provided there will supply you with
 a [JWT][1] access token and refresh token in exchange for your username and
 password.
 

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -1,7 +1,8 @@
 # The DocumentCloud API
 
-All APIs besides the authentication endpoints are served from
-<https://api.www.documentcloud.org/api>.
+API endpoints are served from <https://api.www.documentcloud.org/api>.
+
+Authenticated requests are returned from the same endpoint, however authentication happens at the MuckRock accounts server located at <https://accounts.muckrock.com/>.
 
 ## Overview
 


### PR DESCRIPTION
Hey...

I was working through making requests to the DocumentCloud API today and found a couple of discrepancies when it came to passing authentication keys through a header. The [docs say to preface](https://www.documentcloud.org/help/api#authentication) with `Bearer`, but that didn't work. Once I changed it to `Token` — which matches the [MuckRock docs](https://www.muckrock.com/api/) — it worked.