### PR TITLE
Adds a check that at least 5 event runs have occurred for the Add-On disable email

### DIFF
--- a/documentcloud/addons/models.py
+++ b/documentcloud/addons/models.py
@@ -408,7 +408,7 @@ class AddOnRun(models.Model):
             if status in fail_statuses and all(
                 r.status in fail_statuses
                 for r in self.event.runs.order_by("-created_at")[:5]
-            ):
+            ) and self.event.runs.count()>=5:
                 logger.info("[SET STATUS] disabling %s - %s", self.uuid, self.status)
                 # disable the event
                 self.event.event = Event.disabled


### PR DESCRIPTION
Using the Django queryset count() instead of len(self.event.runs) here as suggested by this Stack Overflow question about Django QuerySets: https://stackoverflow.com/questions/14327036/count-vs-len-on-a-django-queryset