### PR TITLE
Addon disable logs

### DIFF
--- a/documentcloud/addons/admin.py
+++ b/documentcloud/addons/admin.py
@@ -119,7 +119,7 @@ class AddOnDisableLogAdmin(admin.ModelAdmin):
     ]
     list_filter = ["reverted"]
     date_hierarchy = "created_at"
-    readonly_fields = ("created_at",)
+    readonly_fields = ("created_at", "addon_event", "previous_event_state")
 
     actions = ["revert_addon_event"]
 


### PR DESCRIPTION
Logs when Add-Ons get disabled, can navigate by the time that the Add-On was disabled to filter for events. Can mass re-enable disabled Add-Ons and they will reset the Add-Ons to their event state (hourly,daily,weekly) using the "Re-enable add-on(s)" action 
![AddOnDisableLogging](https://github.com/MuckRock/documentcloud/assets/102841251/8ebe3dd6-fe86-44eb-8722-ba74279687f9)
![Reenable](https://github.com/MuckRock/documentcloud/assets/102841251/d9a0a4a6-1878-4d4d-97f0-18a8842eedc4)
