### PR TITLE
only return project memberships that were updated

### DIFF
--- a/documentcloud/documents/tests/test_views.py
+++ b/documentcloud/documents/tests/test_views.py
@@ -4,6 +4,9 @@ from django.db import connection, reset_queries
 from django.test.utils import override_settings
 from rest_framework import status
 
+# Standard Library
+import json
+
 # Third Party
 import pytest
 
@@ -652,14 +655,17 @@ class TestDocumentAPI:
     def test_bulk_update(self, client, user):
         """Test updating multiple documents"""
         client.force_authenticate(user=user)
-        documents = DocumentFactory.create_batch(3, user=user, access=Access.private)
+        documents = DocumentFactory.create_batch(7, user=user, access=Access.private)
         response = client.patch(
             "/api/documents/",
-            [{"id": d.pk, "source": "Daily Planet"} for d in documents[:2]],
+            [{"id": d.pk, "source": "Daily Planet"} for d in documents[:4]],
             format="json",
         )
         assert response.status_code == status.HTTP_200_OK
-        assert Document.objects.filter(source="Daily Planet").count() == 2
+        response_json = json.loads(response.content)
+        assert len(response_json) == 4
+
+        assert Document.objects.filter(source="Daily Planet").count() == 4
 
     def test_bulk_update_bad(self, client, user):
         """Test updating multiple documents, without permissions for all"""

--- a/documentcloud/drf_bulk/views.py
+++ b/documentcloud/drf_bulk/views.py
@@ -36,7 +36,10 @@ class BulkUpdateModelMixin:
             partial=partial,
         )
         serializer.is_valid(raise_exception=True)
-        self.bulk_perform_update(serializer, partial)
+        data = self.bulk_perform_update(serializer, partial)
+        # allow bulk_perform_update to override the response data if needed
+        if data is not None:
+            serializer = self.get_serializer(data, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def bulk_partial_update(self, request, *args, **kwargs):

--- a/documentcloud/projects/tests/test_views.py
+++ b/documentcloud/projects/tests/test_views.py
@@ -431,7 +431,13 @@ class TestProjectMembershipAPI:
             [{"document": d.pk} for d in new_documents],
             format="json",
         )
+
         assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert sorted([d["document"] for d in response_json]) == sorted(
+            [d.id for d in new_documents]
+        )
+
         # all of new and old documents are in the project
         assert {d.pk for d in new_documents + old_documents} == {
             d.pk for d in project.documents.all()


### PR DESCRIPTION
This makes it so the project membership update API only returns the documents that were updated instead of every document in the project, to allow for it to scale to adding documents to very large projects.  This is a non-backwards compatible change, but I don't believe anyone was using the old behavior (I think the old behavior was mostly a mistake).  I pushed this to staging to test out - both that it doesn't break existing functionality and that the performance is improved.