### PR TITLE
Production: Default to responsive embeds

### DIFF
--- a/documentcloud/documents/oembed.py
+++ b/documentcloud/documents/oembed.py
@@ -35,7 +35,7 @@ class DocumentOEmbed(RichOEmbed):
             Document.objects.get_viewable(request.user), pk=kwargs["pk"]
         )
 
-        responsive = query.params.get("responsive") == "1"
+        responsive = query.params.get("responsive", "1") == "1"
         width, height = self.get_dimensions(document, max_width, max_height)
         style = self.get_style(responsive, max_width, max_height)
         oembed = {
@@ -57,7 +57,7 @@ class DocumentOEmbed(RichOEmbed):
         return {"src": src, **extra}
 
     def get_dimensions(self, document, max_width, max_height):
-        default_width = 700
+        default_width = 800
         aspect_ratio = document.aspect_ratio
         if max_width and max_height:
             # preserve user intention and break aspect ratio

--- a/documentcloud/documents/search.py
+++ b/documentcloud/documents/search.py
@@ -782,9 +782,7 @@ def _add_canonical_url(results):
     for result in results:
         id = result["id"]
         slug = result.get("slug", "")
-        result["canonical_url"] = (
-            f"{settings.DOCCLOUD_URL}/documents/{result['id']}-{result.get('slug', '')}/"
-        )
+        result["canonical_url"] = f"{settings.DOCCLOUD_URL}/documents/{id}-{slug}/"
     return results
 
 

--- a/documentcloud/documents/search.py
+++ b/documentcloud/documents/search.py
@@ -780,6 +780,8 @@ def _highlight_notes(response, text_query):
 def _add_canonical_url(results):
 
     for result in results:
+        id = result["id"]
+        slug = result.get("slug", "")
         result["canonical_url"] = (
             f"{settings.DOCCLOUD_URL}/documents/{result['id']}-{result.get('slug', '')}/"
         )

--- a/documentcloud/documents/search.py
+++ b/documentcloud/documents/search.py
@@ -780,9 +780,9 @@ def _highlight_notes(response, text_query):
 def _add_canonical_url(results):
 
     for result in results:
-        id = result["id"]
+        doc_id = result["id"]
         slug = result.get("slug", "")
-        result["canonical_url"] = f"{settings.DOCCLOUD_URL}/documents/{id}-{slug}/"
+        result["canonical_url"] = f"{settings.DOCCLOUD_URL}/documents/{doc_id}-{slug}/"
     return results
 
 

--- a/documentcloud/documents/search.py
+++ b/documentcloud/documents/search.py
@@ -781,7 +781,7 @@ def _add_canonical_url(results):
 
     for result in results:
         result["canonical_url"] = (
-            f"{settings.DOCCLOUD_URL}/documents/{result['id']}-{result.get('slug', '')}"
+            f"{settings.DOCCLOUD_URL}/documents/{result['id']}-{result.get('slug', '')}/"
         )
     return results
 

--- a/documentcloud/documents/serializers.py
+++ b/documentcloud/documents/serializers.py
@@ -444,7 +444,7 @@ class DocumentSerializer(FlexFieldsModelSerializer):
         return request.user.has_perm("documents.change_document", obj)
 
     def get_canonical_url(self, obj):
-        return f"{settings.DOCCLOUD_URL}/documents/{obj.pk}-{obj.slug}"
+        return f"{settings.DOCCLOUD_URL}/documents/{obj.pk}-{obj.slug}/"
 
     def bulk_create_attrs(self, attrs):
         """Set the slug on bulk creation"""

--- a/documentcloud/templates/oembed/document.html
+++ b/documentcloud/templates/oembed/document.html
@@ -1,8 +1,1 @@
-<iframe
-  src="{{ src }}"
-  title="{{ title }} (Hosted by DocumentCloud)"
-  width="{{ width }}"
-  height="{{ height }}"
-  style="border: 1px solid #aaa;{{ style }}"
-  sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"
-></iframe>
+<iframe src="{{ src }}" title="{{ title }} (Hosted by DocumentCloud)" width="{{ width }}" height="{{ height }}" style="border: 1px solid #aaa;{{ style }}" sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"></iframe>

--- a/documentcloud/templates/oembed/project.html
+++ b/documentcloud/templates/oembed/project.html
@@ -1,8 +1,1 @@
-<iframe
-  src="{{ src }}"
-  title="{{ title }} (Hosted by DocumentCloud)"
-  width="{{ width }}"
-  height="{{ height }}"
-  style="border: 1px solid #aaa;"
-  sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"
-></iframe>
+<iframe src="{{ src }}" title="{{ title }} (Hosted by DocumentCloud)" width="{{ width }}" height="{{ height }}" style="border: 1px solid #aaa;" sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"></iframe>


### PR DESCRIPTION
Fixes #266 

- Embeds default to being responsive, instead of fixed-width
- Remove newlines from iframes (to avoid CMS issues)
- Add trailing slashes to canonical URLs to match the frontend

Example: https://api.muckcloud.com/api/oembed/?url=https://www.staging.documentcloud.org/documents/25034-2017-08-16t152156_scientology_preprocessed_releasepdf