### PR TITLE
Add max-age header to json file response

### DIFF
--- a/documentcloud/core/views.py
+++ b/documentcloud/core/views.py
@@ -11,6 +11,7 @@ from django.http.response import (
 )
 from django.shortcuts import get_object_or_404, redirect
 from django.views.decorators.csrf import csrf_exempt
+from django.utils.cache import patch_cache_control
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView
 
@@ -60,7 +61,7 @@ class FileServer(APIView):
 
         if request.META.get("HTTP_ACCEPT", "").startswith("application/json"):
             response = JsonResponse({"location": url})
-            response.headers["max-age"] = 300
+            patch_cache_control(response, max_age=300)
             return response
         else:
             return HttpResponseRedirect(url)

--- a/documentcloud/core/views.py
+++ b/documentcloud/core/views.py
@@ -10,8 +10,8 @@ from django.http.response import (
     JsonResponse,
 )
 from django.shortcuts import get_object_or_404, redirect
-from django.views.decorators.csrf import csrf_exempt
 from django.utils.cache import patch_cache_control
+from django.views.decorators.csrf import csrf_exempt
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView
 

--- a/documentcloud/core/views.py
+++ b/documentcloud/core/views.py
@@ -59,7 +59,9 @@ class FileServer(APIView):
             )
 
         if request.META.get("HTTP_ACCEPT", "").startswith("application/json"):
-            return JsonResponse({"location": url})
+            response = JsonResponse({"location": url})
+            response.headers["max-age"] = 300
+            return response
         else:
             return HttpResponseRedirect(url)
 


### PR DESCRIPTION
Attempting to solve https://github.com/MuckRock/documentcloud-frontend/issues/1002

The JSON response was getting cached by cloudflare (tested by fetching in the browser and with curl).