### PR TITLE
Return `iframe` HTML from oEmbed API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,6 +282,7 @@ documentcloud/media/
 
 .pytest_cache/
 .env
+.envrc
 .envs/*
 
 # Generated test reports

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -6,7 +6,6 @@ ENV PYTHONUNBUFFERED 1
 USER root
 
 RUN apt-get -qq -y update && \
-  apt-get -qq -y upgrade && \
   apt-get -qq -y install \
   # Pip dependencies
   python3-pip \

--- a/documentcloud/documents/oembed.py
+++ b/documentcloud/documents/oembed.py
@@ -32,9 +32,8 @@ class DocumentOEmbed(RichOEmbed):
         document = get_object_or_404(
             Document.objects.get_viewable(request.user), pk=kwargs["pk"]
         )
-        responsive = query.params.get("responsive", "1") == "1"
         width, height = self.get_dimensions(document, max_width, max_height)
-        style = self.get_style(responsive, max_width, max_height)
+        style = self.get_style(max_width, max_height)
         oembed = {
             "title": document.title,
             "width": width,
@@ -66,7 +65,7 @@ class DocumentOEmbed(RichOEmbed):
         else:
             return default_width, int(default_width / aspect_ratio)
 
-    def get_style(self, responsive, max_width, max_height):
+    def get_style(self, max_width, max_height):
         # Responsive is now the default width setting
         # 100% width and 100vh - 100px height (800px fallback for old browsers)
         style = " width: 100%; height: 800px; height: calc(100vh - 100px);"
@@ -126,7 +125,7 @@ class NoteOEmbed(RichOEmbed):
         ),
     ]
 
-    def response(self, request, query, **kwargs):
+    def response(self, request, query, max_width=None, max_height=None, **kwargs):
         document = get_object_or_404(
             Document.objects.get_viewable(request.user), pk=kwargs["doc_pk"]
         )
@@ -134,8 +133,7 @@ class NoteOEmbed(RichOEmbed):
             document.notes.get_viewable(request.user, document), pk=kwargs["pk"]
         )
         oembed = {"title": note.title}
-        # pylint: disable=consider-using-f-string
-        src = f"{settings.DOCCLOUD_EMBED_URL}/documents/{document.pk}/annotations/{note.pk}/"
+        src = f"{settings.DOCCLOUD_EMBED_URL}/documents/{document.pk}/annotations/{note.pk}/" # pylint: disable=line-too-long
         if query:
             src = f"{src}?{query}"
         context = {

--- a/documentcloud/documents/oembed.py
+++ b/documentcloud/documents/oembed.py
@@ -96,7 +96,7 @@ class PageOEmbed(DocumentOEmbed):
 
     def get_context(self, document, query, extra, **kwargs):
         page = int(kwargs["page"])
-        src = f"{settings.DOCCLOUD_EMBED_URL}/documents/{document.pk}/pages/{page}"
+        src = f"{settings.DOCCLOUD_EMBED_URL}/documents/{document.pk}/pages/{page}/"
         if query:
             src = f"{src}?{query}"
         return {
@@ -135,7 +135,7 @@ class NoteOEmbed(RichOEmbed):
         )
         oembed = {"title": note.title}
         # pylint: disable=consider-using-f-string
-        src = f"{settings.DOCCLOUD_EMBED_URL}/documents/{document.pk}/annotations/{note.pk}"
+        src = f"{settings.DOCCLOUD_EMBED_URL}/documents/{document.pk}/annotations/{note.pk}/"
         if query:
             src = f"{src}?{query}"
         context = {

--- a/documentcloud/documents/oembed.py
+++ b/documentcloud/documents/oembed.py
@@ -133,7 +133,7 @@ class NoteOEmbed(RichOEmbed):
             document.notes.get_viewable(request.user, document), pk=kwargs["pk"]
         )
         oembed = {"title": note.title}
-        src = f"{settings.DOCCLOUD_EMBED_URL}/documents/{document.pk}/annotations/{note.pk}/" # pylint: disable=line-too-long
+        src = f"{settings.DOCCLOUD_EMBED_URL}/documents/{document.pk}/annotations/{note.pk}/"  # pylint: disable=line-too-long
         if query:
             src = f"{src}?{query}"
         context = {

--- a/documentcloud/documents/oembed.py
+++ b/documentcloud/documents/oembed.py
@@ -135,7 +135,7 @@ class NoteOEmbed(RichOEmbed):
         oembed = {"title": note.title}
         src = (
             f"{settings.DOCCLOUD_EMBED_URL}/documents/"
-            "{document.pk}/annotations/{note.pk}/"
+            f"{document.pk}/annotations/{note.pk}/"
         )
         if query:
             src = f"{src}?{query}"

--- a/documentcloud/documents/oembed.py
+++ b/documentcloud/documents/oembed.py
@@ -133,7 +133,10 @@ class NoteOEmbed(RichOEmbed):
             document.notes.get_viewable(request.user, document), pk=kwargs["pk"]
         )
         oembed = {"title": note.title}
-        src = f"{settings.DOCCLOUD_EMBED_URL}/documents/{document.pk}/annotations/{note.pk}/"  # pylint: disable=line-too-long
+        src = (
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/"
+            "{document.pk}/annotations/{note.pk}/"
+        )
         if query:
             src = f"{src}?{query}"
         context = {

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -1,8 +1,13 @@
+# Django
 from django.conf import settings
 from django.test import RequestFactory, TestCase
+
+# Standard Library
 from unittest import mock
+
+# DocumentCloud
 from documentcloud.documents.models import Document
-from documentcloud.documents.oembed import DocumentOEmbed, PageOEmbed, NoteOEmbed
+from documentcloud.documents.oembed import DocumentOEmbed, NoteOEmbed, PageOEmbed
 from documentcloud.oembed.utils import Query
 
 
@@ -128,21 +133,21 @@ class DocumentOEmbedTest(TestCase):
         style = self.document_oembed.get_style(600, None)
         self.assertEqual(
             style,
-            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;", # pylint: disable=line-too-long
+            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;",  # pylint: disable=line-too-long
         )
 
         # Test with max_height only
         style = self.document_oembed.get_style(None, 400)
         self.assertEqual(
             style,
-            " width: 100%; height: 800px; height: calc(100vh - 100px); max-height: 400px;", # pylint: disable=line-too-long
+            " width: 100%; height: 800px; height: calc(100vh - 100px); max-height: 400px;",  # pylint: disable=line-too-long
         )
 
         # Test with both max dimensions
         style = self.document_oembed.get_style(600, 400)
         self.assertEqual(
             style,
-            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px; max-height: 400px;", # pylint: disable=line-too-long
+            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px; max-height: 400px;",  # pylint: disable=line-too-long
         )
 
 
@@ -318,7 +323,7 @@ class NoteOEmbedTest(TestCase):
         # Check that the response contains an iframe with expected attributes
         self.assertIn('<iframe src="', response["html"])
         self.assertIn(
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?responsive=1", # pylint: disable=line-too-long
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?responsive=1",  # pylint: disable=line-too-long
             response["html"],
         )
         self.assertIn('title="Test Note (Hosted by DocumentCloud)"', response["html"])

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -5,243 +5,286 @@ from documentcloud.documents.models import Document
 from documentcloud.documents.oembed import DocumentOEmbed, PageOEmbed, NoteOEmbed
 from documentcloud.oembed.utils import Query
 
+
 class DocumentOEmbedTest(TestCase):
-  def setUp(self):
-    self.factory = RequestFactory()
-    self.user = mock.MagicMock()
-    self.document = mock.MagicMock(spec=Document)
-    self.document.title = "Test Document"
-    self.document.aspect_ratio = 1.5
-    self.document.get_absolute_url.return_value = "/documents/123/"
-    
-    # Mock the Document manager
-    self.document_queryset = mock.MagicMock()
-    self.document_queryset.get_viewable.return_value = self.document_queryset
-    Document.objects = self.document_queryset
-    
-    # Create a DocumentOEmbed instance
-    self.document_oembed = DocumentOEmbed()
-    
-    # Mock get_object_or_404
-    self.get_object_mock = mock.patch(
-      "documentcloud.documents.oembed.get_object_or_404", 
-      return_value=self.document
-    )
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = mock.MagicMock()
+        self.document = mock.MagicMock(spec=Document)
+        self.document.title = "Test Document"
+        self.document.aspect_ratio = 1.5
+        self.document.get_absolute_url.return_value = "/documents/123/"
 
-  def test_document_oembed_response(self):
-    """Test the response method of DocumentOEmbed"""
-    request = self.factory.get("/oembed/")
-    request.user = self.user
-    query = Query("responsive=1")
-    
-    with self.get_object_mock:
-      response = self.document_oembed.response(
-        request, query, max_width=600, max_height=None, pk=123
-      )
-    
-    # Check response properties
-    self.assertEqual(response["version"], "1.0")
-    self.assertEqual(response["type"], "rich")
-    self.assertEqual(response["title"], "Test Document")
-    self.assertEqual(response["width"], 600)
-    self.assertEqual(response["height"], 400)
-    
-    # Check that the response contains an iframe with expected attributes
-    self.assertIn('<iframe src="', response["html"])
-    self.assertIn(f'{settings.DOCCLOUD_EMBED_URL}/documents/123/?responsive=1', response["html"])
-    self.assertIn('title="Test Document (Hosted by DocumentCloud)"', response["html"])
-    self.assertIn('width="600" height="400"', response["html"])
-    self.assertIn('style="border: 1px solid #aaa; width: 100%; height: 800px;', response["html"])
-    self.assertIn('sandbox="allow-scripts allow-same-origin allow-popups allow-forms', response["html"])
-    
-  def test_document_oembed_get_dimensions(self):
-    """Test the get_dimensions method of DocumentOEmbed"""
-    # Test with both max_width and max_height - should preserve both dimensions
-    width, height = self.document_oembed.get_dimensions(self.document, 600, 500)
-    self.assertEqual(width, 600)
-    self.assertEqual(height, 500)
-    
-    # Test with max_width less than default
-    width, height = self.document_oembed.get_dimensions(self.document, 500, None)
-    self.assertEqual(width, 500)
-    self.assertEqual(height, 333)  # 500/1.5 = 333.33...
-    
-    # Test with only max_height
-    width, height = self.document_oembed.get_dimensions(self.document, None, 450)
-    self.assertEqual(width, 675)  # 450*1.5 = 675
-    self.assertEqual(height, 450)
-    
-    # Test with no max dimensions
-    width, height = self.document_oembed.get_dimensions(self.document, None, None)
-    self.assertEqual(width, 800)  # Should be default
-    self.assertEqual(height, 533)  # 800/1.5 = 533.33...
+        # Mock the Document manager
+        self.document_queryset = mock.MagicMock()
+        self.document_queryset.get_viewable.return_value = self.document_queryset
+        Document.objects = self.document_queryset
 
-  def test_document_oembed_get_context(self):
-    """Test the get_context method of DocumentOEmbed"""
-    query = Query("param=value")
-    extra = {"width": 600, "height": 400, "style": ""}
-    
-    context = self.document_oembed.get_context(self.document, query, extra)
-    
-    expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?param=value"
-    self.assertEqual(context["src"], expected_src)
-    self.assertEqual(context["width"], 600)
-    self.assertEqual(context["height"], 400)
-    self.assertEqual(context["style"], "")
-    
-  def test_document_oembed_get_style(self):
-    """Test the get_style method of DocumentOEmbed"""
-    # Test responsive with no max dimensions
-    style = self.document_oembed.get_style(True, None, None)
-    self.assertEqual(style, " width: 100%; height: 800px; height: calc(100vh - 100px);")
-    
-    # Test with max_width only
-    style = self.document_oembed.get_style(True, 600, None)
-    self.assertEqual(style, " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;")
-    
-    # Test with max_height only
-    style = self.document_oembed.get_style(True, None, 400)
-    self.assertEqual(style, " width: 100%; height: 800px; height: calc(100vh - 100px); max-height: 400px;")
-    
-    # Test with both max dimensions
-    style = self.document_oembed.get_style(True, 600, 400)
-    self.assertEqual(style, " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px; max-height: 400px;")
+        # Create a DocumentOEmbed instance
+        self.document_oembed = DocumentOEmbed()
+
+        # Mock get_object_or_404
+        self.get_object_mock = mock.patch(
+            "documentcloud.documents.oembed.get_object_or_404",
+            return_value=self.document,
+        )
+
+    def test_document_oembed_response(self):
+        """Test the response method of DocumentOEmbed"""
+        request = self.factory.get("/oembed/")
+        request.user = self.user
+        query = Query("responsive=1")
+
+        with self.get_object_mock:
+            response = self.document_oembed.response(
+                request, query, max_width=600, max_height=None, pk=123
+            )
+
+        # Check response properties
+        self.assertEqual(response["version"], "1.0")
+        self.assertEqual(response["type"], "rich")
+        self.assertEqual(response["title"], "Test Document")
+        self.assertEqual(response["width"], 600)
+        self.assertEqual(response["height"], 400)
+
+        # Check that the response contains an iframe with expected attributes
+        self.assertIn('<iframe src="', response["html"])
+        self.assertIn(
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?responsive=1",
+            response["html"],
+        )
+        self.assertIn(
+            'title="Test Document (Hosted by DocumentCloud)"', response["html"]
+        )
+        self.assertIn('width="600" height="400"', response["html"])
+        self.assertIn(
+            'style="border: 1px solid #aaa; width: 100%; height: 800px;',
+            response["html"],
+        )
+        self.assertIn(
+            'sandbox="allow-scripts allow-same-origin allow-popups allow-forms',
+            response["html"],
+        )
+
+    def test_document_oembed_get_dimensions(self):
+        """Test the get_dimensions method of DocumentOEmbed"""
+        # Test with both max_width and max_height - should preserve both dimensions
+        width, height = self.document_oembed.get_dimensions(self.document, 600, 500)
+        self.assertEqual(width, 600)
+        self.assertEqual(height, 500)
+
+        # Test with max_width less than default
+        width, height = self.document_oembed.get_dimensions(self.document, 500, None)
+        self.assertEqual(width, 500)
+        self.assertEqual(height, 333)  # 500/1.5 = 333.33...
+
+        # Test with only max_height
+        width, height = self.document_oembed.get_dimensions(self.document, None, 450)
+        self.assertEqual(width, 675)  # 450*1.5 = 675
+        self.assertEqual(height, 450)
+
+        # Test with no max dimensions
+        width, height = self.document_oembed.get_dimensions(self.document, None, None)
+        self.assertEqual(width, 800)  # Should be default
+        self.assertEqual(height, 533)  # 800/1.5 = 533.33...
+
+    def test_document_oembed_get_context(self):
+        """Test the get_context method of DocumentOEmbed"""
+        query = Query("param=value")
+        extra = {"width": 600, "height": 400, "style": ""}
+
+        context = self.document_oembed.get_context(self.document, query, extra)
+
+        expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?param=value"
+        self.assertEqual(context["src"], expected_src)
+        self.assertEqual(context["width"], 600)
+        self.assertEqual(context["height"], 400)
+        self.assertEqual(context["style"], "")
+
+    def test_document_oembed_get_style(self):
+        """Test the get_style method of DocumentOEmbed"""
+        # Test responsive with no max dimensions
+        style = self.document_oembed.get_style(True, None, None)
+        self.assertEqual(
+            style, " width: 100%; height: 800px; height: calc(100vh - 100px);"
+        )
+
+        # Test with max_width only
+        style = self.document_oembed.get_style(True, 600, None)
+        self.assertEqual(
+            style,
+            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;",
+        )
+
+        # Test with max_height only
+        style = self.document_oembed.get_style(True, None, 400)
+        self.assertEqual(
+            style,
+            " width: 100%; height: 800px; height: calc(100vh - 100px); max-height: 400px;",
+        )
+
+        # Test with both max dimensions
+        style = self.document_oembed.get_style(True, 600, 400)
+        self.assertEqual(
+            style,
+            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px; max-height: 400px;",
+        )
+
 
 class PageOEmbedTest(TestCase):
-  def setUp(self):
-    self.factory = RequestFactory()
-    self.user = mock.MagicMock()
-    self.document = mock.MagicMock(spec=Document)
-    self.document.pk = 123
-    self.document.title = "Test Document"
-    self.document.aspect_ratio = 1.5
-    self.document.get_absolute_url.return_value = "/documents/123/"
-    
-    # Mock the Document manager
-    self.document_queryset = mock.MagicMock()
-    self.document_queryset.get_viewable.return_value = self.document_queryset
-    Document.objects = self.document_queryset
-    
-    # Create a PageOEmbed instance
-    self.page_oembed = PageOEmbed()
-    
-    # Mock get_object_or_404
-    self.get_object_mock = mock.patch(
-      "documentcloud.documents.oembed.get_object_or_404", 
-      return_value=self.document
-    )
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = mock.MagicMock()
+        self.document = mock.MagicMock(spec=Document)
+        self.document.pk = 123
+        self.document.title = "Test Document"
+        self.document.aspect_ratio = 1.5
+        self.document.get_absolute_url.return_value = "/documents/123/"
 
-  def test_page_oembed_response(self):
-    """Test the response method of PageOEmbed"""
-    request = self.factory.get("/oembed/")
-    request.user = self.user
-    query = Query("responsive=1")
-    
-    with self.get_object_mock:
-      response = self.page_oembed.response(
-        request, query, max_width=600, max_height=None, pk=123, page=1
-      )
-    
-    # Check response properties
-    self.assertEqual(response["version"], "1.0")
-    self.assertEqual(response["type"], "rich")
-    self.assertEqual(response["title"], "Test Document")
-    self.assertEqual(response["width"], 600)
-    self.assertEqual(response["height"], 400)
-    
-    # Check that the response contains an iframe with expected attributes
-    self.assertIn('<iframe src="', response["html"])
-    self.assertIn(f'{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1?responsive=1', response["html"])
-    self.assertIn('title="Test Document (Hosted by DocumentCloud)"', response["html"])
-    self.assertIn('width="600" height="400"', response["html"])
-    self.assertIn('style="border: 1px solid #aaa; width: 100%; height: 800px;', response["html"])
-    self.assertIn('sandbox="allow-scripts allow-same-origin allow-popups allow-forms', response["html"])
-    
-  def test_page_oembed_get_dimensions(self):
-    """Test the get_dimensions method of PageOEmbed"""
-    # Test with max_width less than default
-    width, height = self.page_oembed.get_dimensions(self.document, 500, None)
-    self.assertEqual(width, 500)
-    self.assertEqual(height, 333)  
-    
-    # Test with max_width greater than default
-    width, height = self.page_oembed.get_dimensions(self.document, 800, None)
-    self.assertEqual(height, 533)  # Should be calculated based on aspect ratio
-    
-    # Test with no max dimensions
-    width, height = self.page_oembed.get_dimensions(self.document, None, None)
-    self.assertEqual(width, 800)  # Should be default
-    self.assertEqual(height, 533)  # Should be calculated based on aspect ratio
+        # Mock the Document manager
+        self.document_queryset = mock.MagicMock()
+        self.document_queryset.get_viewable.return_value = self.document_queryset
+        Document.objects = self.document_queryset
 
-  def test_page_oembed_get_context(self):
-    """Test the get_context method of PageOEmbed"""
-    query = Query("param=value")
-    extra = {"width": 600, "height": 400, "style": ""}
-    
-    context = self.page_oembed.get_context(self.document, query, extra, page=2)
-    
-    expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/2?param=value"
-    self.assertEqual(context["src"], expected_src)
-    self.assertEqual(context["width"], 600)
-    self.assertEqual(context["height"], 400)
-    self.assertEqual(context["style"], "")
+        # Create a PageOEmbed instance
+        self.page_oembed = PageOEmbed()
+
+        # Mock get_object_or_404
+        self.get_object_mock = mock.patch(
+            "documentcloud.documents.oembed.get_object_or_404",
+            return_value=self.document,
+        )
+
+    def test_page_oembed_response(self):
+        """Test the response method of PageOEmbed"""
+        request = self.factory.get("/oembed/")
+        request.user = self.user
+        query = Query("responsive=1")
+
+        with self.get_object_mock:
+            response = self.page_oembed.response(
+                request, query, max_width=600, max_height=None, pk=123, page=1
+            )
+
+        # Check response properties
+        self.assertEqual(response["version"], "1.0")
+        self.assertEqual(response["type"], "rich")
+        self.assertEqual(response["title"], "Test Document")
+        self.assertEqual(response["width"], 600)
+        self.assertEqual(response["height"], 400)
+
+        # Check that the response contains an iframe with expected attributes
+        self.assertIn('<iframe src="', response["html"])
+        self.assertIn(
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1?responsive=1",
+            response["html"],
+        )
+        self.assertIn(
+            'title="Test Document (Hosted by DocumentCloud)"', response["html"]
+        )
+        self.assertIn('width="600" height="400"', response["html"])
+        self.assertIn(
+            'style="border: 1px solid #aaa; width: 100%; height: 800px;',
+            response["html"],
+        )
+        self.assertIn(
+            'sandbox="allow-scripts allow-same-origin allow-popups allow-forms',
+            response["html"],
+        )
+
+    def test_page_oembed_get_dimensions(self):
+        """Test the get_dimensions method of PageOEmbed"""
+        # Test with max_width less than default
+        width, height = self.page_oembed.get_dimensions(self.document, 500, None)
+        self.assertEqual(width, 500)
+        self.assertEqual(height, 333)
+
+        # Test with max_width greater than default
+        width, height = self.page_oembed.get_dimensions(self.document, 800, None)
+        self.assertEqual(height, 533)  # Should be calculated based on aspect ratio
+
+        # Test with no max dimensions
+        width, height = self.page_oembed.get_dimensions(self.document, None, None)
+        self.assertEqual(width, 800)  # Should be default
+        self.assertEqual(height, 533)  # Should be calculated based on aspect ratio
+
+    def test_page_oembed_get_context(self):
+        """Test the get_context method of PageOEmbed"""
+        query = Query("param=value")
+        extra = {"width": 600, "height": 400, "style": ""}
+
+        context = self.page_oembed.get_context(self.document, query, extra, page=2)
+
+        expected_src = (
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/2?param=value"
+        )
+        self.assertEqual(context["src"], expected_src)
+        self.assertEqual(context["width"], 600)
+        self.assertEqual(context["height"], 400)
+        self.assertEqual(context["style"], "")
+
 
 class NoteOEmbedTest(TestCase):
-  def setUp(self):
-    self.factory = RequestFactory()
-    self.user = mock.MagicMock()
-    
-    # Mock the Document
-    self.document = mock.MagicMock(spec=Document)
-    self.document.title = "Test Document"
-    self.document.get_absolute_url.return_value = "/documents/123/"
-    self.document.pk = 123
-    
-    # Mock the Note
-    self.note = mock.MagicMock()
-    self.note.title = "Test Note"
-    self.note.pk = 456
-    
-    # Mock Document.notes.get_viewable
-    note_queryset = mock.MagicMock()
-    note_queryset.get_viewable.return_value = note_queryset
-    self.document.notes = note_queryset
-    
-    # Mock the Document manager
-    self.document_queryset = mock.MagicMock()
-    self.document_queryset.get_viewable.return_value = self.document_queryset
-    Document.objects = self.document_queryset
-    
-    # Create a NoteOEmbed instance
-    self.note_oembed = NoteOEmbed()
-    
-    # Mock get_object_or_404 for both document and note
-    self.get_object_mock = mock.patch(
-      "documentcloud.documents.oembed.get_object_or_404",
-      side_effect=[self.document, self.note]
-    )
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = mock.MagicMock()
 
-  def test_note_oembed_response(self):
-    """Test the response method of NoteOEmbed"""
-    request = self.factory.get("/oembed/")
-    request.user = self.user
-    query = Query("responsive=1")
-    
-    with self.get_object_mock:
-      response = self.note_oembed.response(
-        request, query, max_width=600, max_height=None, doc_pk=123, pk=456
-      )
-    
-    # Check response properties
-    self.assertEqual(response["version"], "1.0")
-    self.assertEqual(response["type"], "rich")
-    self.assertEqual(response["title"], "Test Note")
-    
-    # Check that the response contains an iframe with expected attributes
-    self.assertIn('<iframe src="', response["html"])
-    self.assertIn(f'{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456?responsive=1', response["html"])
-    self.assertIn('title="Test Note (Hosted by DocumentCloud)"', response["html"])
-    self.assertIn('width="100%" height="500px"', response["html"])
-    self.assertIn('style="border: 1px solid #aaa;', response["html"])
-    self.assertIn('sandbox="allow-scripts allow-same-origin allow-popups allow-forms', response["html"])
-    
+        # Mock the Document
+        self.document = mock.MagicMock(spec=Document)
+        self.document.title = "Test Document"
+        self.document.get_absolute_url.return_value = "/documents/123/"
+        self.document.pk = 123
+
+        # Mock the Note
+        self.note = mock.MagicMock()
+        self.note.title = "Test Note"
+        self.note.pk = 456
+
+        # Mock Document.notes.get_viewable
+        note_queryset = mock.MagicMock()
+        note_queryset.get_viewable.return_value = note_queryset
+        self.document.notes = note_queryset
+
+        # Mock the Document manager
+        self.document_queryset = mock.MagicMock()
+        self.document_queryset.get_viewable.return_value = self.document_queryset
+        Document.objects = self.document_queryset
+
+        # Create a NoteOEmbed instance
+        self.note_oembed = NoteOEmbed()
+
+        # Mock get_object_or_404 for both document and note
+        self.get_object_mock = mock.patch(
+            "documentcloud.documents.oembed.get_object_or_404",
+            side_effect=[self.document, self.note],
+        )
+
+    def test_note_oembed_response(self):
+        """Test the response method of NoteOEmbed"""
+        request = self.factory.get("/oembed/")
+        request.user = self.user
+        query = Query("responsive=1")
+
+        with self.get_object_mock:
+            response = self.note_oembed.response(
+                request, query, max_width=600, max_height=None, doc_pk=123, pk=456
+            )
+
+        # Check response properties
+        self.assertEqual(response["version"], "1.0")
+        self.assertEqual(response["type"], "rich")
+        self.assertEqual(response["title"], "Test Note")
+
+        # Check that the response contains an iframe with expected attributes
+        self.assertIn('<iframe src="', response["html"])
+        self.assertIn(
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456?responsive=1",
+            response["html"],
+        )
+        self.assertIn('title="Test Note (Hosted by DocumentCloud)"', response["html"])
+        self.assertIn('width="100%" height="500px"', response["html"])
+        self.assertIn('style="border: 1px solid #aaa;', response["html"])
+        self.assertIn(
+            'sandbox="allow-scripts allow-same-origin allow-popups allow-forms',
+            response["html"],
+        )

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -15,6 +15,7 @@ from documentcloud.oembed.utils import Query
 
 
 class TestDocumentOEmbed:
+    # pylint: disable=too-many-instance-attributes
     @pytest.fixture(autouse=True)
     def setup(self):
         self.factory = RequestFactory()
@@ -44,9 +45,9 @@ class TestDocumentOEmbed:
             return_value=self.document,
         )
         self.mock_get_object = self.get_object_patcher.start()
-        
+
         yield
-        
+
         # Teardown
         Document.objects = self.original_objects
         self.get_object_patcher.stop()
@@ -70,11 +71,20 @@ class TestDocumentOEmbed:
 
         # Check that the response contains an iframe with expected attributes
         assert '<iframe src="' in response["html"]
-        assert f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?responsive=1" in response["html"]
+        assert (
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?responsive=1"
+            in response["html"]
+        )
         assert 'title="Test Document (Hosted by DocumentCloud)"' in response["html"]
         assert 'width="600" height="400"' in response["html"]
-        assert 'style="border: 1px solid #aaa; width: 100%; height: 800px;' in response["html"]
-        assert 'sandbox="allow-scripts allow-same-origin allow-popups allow-forms' in response["html"]
+        assert (
+            'style="border: 1px solid #aaa; width: 100%; height: 800px;'
+            in response["html"]
+        )
+        assert (
+            'sandbox="allow-scripts allow-same-origin allow-popups allow-forms'
+            in response["html"]
+        )
 
     def test_document_oembed_get_dimensions(self):
         """Test the get_dimensions method of DocumentOEmbed"""
@@ -105,7 +115,9 @@ class TestDocumentOEmbed:
 
         context = self.document_oembed.get_context(self.document, query, extra)
 
-        expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?param=value"
+        expected_src = (
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?param=value"
+        )
         assert context["src"] == expected_src
         assert context["width"] == 600
         assert context["height"] == 400
@@ -119,18 +131,31 @@ class TestDocumentOEmbed:
 
         # Test with max_width only
         style = self.document_oembed.get_style(600, None)
-        assert style == " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;"
+        assert (
+            style
+            == " width: 100%; height: 800px; height: calc(100vh - 100px); "
+            "max-width: 600px;"
+        )
 
         # Test with max_height only
         style = self.document_oembed.get_style(None, 400)
-        assert style == " width: 100%; height: 800px; height: calc(100vh - 100px); max-height: 400px;"
+        assert (
+            style
+            == " width: 100%; height: 800px; height: calc(100vh - 100px); "
+            "max-height: 400px;"
+        )
 
         # Test with both max dimensions
         style = self.document_oembed.get_style(600, 400)
-        assert style == " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px; max-height: 400px;"
+        assert (
+            style
+            == " width: 100%; height: 800px; height: calc(100vh - 100px); "
+            "max-width: 600px; max-height: 400px;"
+        )
 
 
 class TestPageOEmbed:
+    # pylint: disable=too-many-instance-attributes
     @pytest.fixture(autouse=True)
     def setup(self):
         self.factory = RequestFactory()
@@ -160,9 +185,9 @@ class TestPageOEmbed:
             return_value=self.document,
         )
         self.mock_get_object = self.get_object_patcher.start()
-        
+
         yield
-        
+
         # Teardown
         Document.objects = self.original_objects
         self.get_object_patcher.stop()
@@ -186,11 +211,20 @@ class TestPageOEmbed:
 
         # Check that the response contains an iframe with expected attributes
         assert '<iframe src="' in response["html"]
-        assert f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1/?responsive=1" in response["html"]
+        assert (
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1/?responsive=1"
+            in response["html"]
+        )
         assert 'title="Test Document (Hosted by DocumentCloud)"' in response["html"]
         assert 'width="600" height="400"' in response["html"]
-        assert 'style="border: 1px solid #aaa; width: 100%; height: 800px;' in response["html"]
-        assert 'sandbox="allow-scripts allow-same-origin allow-popups allow-forms' in response["html"]
+        assert (
+            'style="border: 1px solid #aaa; width: 100%; height: 800px;'
+            in response["html"]
+        )
+        assert (
+            'sandbox="allow-scripts allow-same-origin allow-popups allow-forms'
+            in response["html"]
+        )
 
     def test_page_oembed_get_dimensions(self):
         """Test the get_dimensions method of PageOEmbed"""
@@ -215,7 +249,9 @@ class TestPageOEmbed:
 
         context = self.page_oembed.get_context(self.document, query, extra, page=2)
 
-        expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/2/?param=value"
+        expected_src = (
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/2/?param=value"
+        )
         assert context["src"] == expected_src
         assert context["width"] == 600
         assert context["height"] == 400
@@ -223,6 +259,7 @@ class TestPageOEmbed:
 
 
 class TestNoteOEmbed:
+    # pylint: disable=too-many-instance-attributes
     @pytest.fixture(autouse=True)
     def setup(self):
         self.factory = RequestFactory()
@@ -264,9 +301,9 @@ class TestNoteOEmbed:
             side_effect=[self.document, self.note],
         )
         self.mock_get_object = self.get_object_patcher.start()
-        
+
         yield
-        
+
         # Teardown
         Document.objects = self.original_objects
         self.get_object_patcher.stop()
@@ -288,8 +325,14 @@ class TestNoteOEmbed:
 
         # Check that the response contains an iframe with expected attributes
         assert '<iframe src="' in response["html"]
-        assert f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?responsive=1" in response["html"]
+        assert (
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?responsive=1"
+            in response["html"]
+        )
         assert 'title="Test Note (Hosted by DocumentCloud)"' in response["html"]
         assert 'width="100%" height="500px"' in response["html"]
         assert 'style="border: 1px solid #aaa;' in response["html"]
-        assert 'sandbox="allow-scripts allow-same-origin allow-popups allow-forms' in response["html"]
+        assert (
+            'sandbox="allow-scripts allow-same-origin allow-popups allow-forms'
+            in response["html"]
+        )

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -1,0 +1,81 @@
+from django.conf import settings
+from django.test import RequestFactory, TestCase
+from unittest import mock
+from documentcloud.documents.models import Document
+from documentcloud.documents.oembed import PageOEmbed
+from documentcloud.oembed.utils import Query
+
+
+class PageOEmbedTest(TestCase):
+  def setUp(self):
+    self.factory = RequestFactory()
+    self.user = mock.MagicMock()
+    self.document = mock.MagicMock(spec=Document)
+    self.document.title = "Test Document"
+    self.document.aspect_ratio = 1.5
+    self.document.get_absolute_url.return_value = "/documents/123/"
+    
+    # Mock the Document manager
+    self.document_queryset = mock.MagicMock()
+    self.document_queryset.get_viewable.return_value = self.document_queryset
+    Document.objects = self.document_queryset
+    
+    # Create a PageOEmbed instance
+    self.page_oembed = PageOEmbed()
+    
+    # Mock get_object_or_404
+    self.get_object_mock = mock.patch(
+      "documentcloud.documents.oembed.get_object_or_404", 
+      return_value=self.document
+    )
+
+  def test_page_oembed_response(self):
+    """Test the response method of PageOEmbed"""
+    request = self.factory.get("/oembed/")
+    request.user = self.user
+    query = Query("responsive=1")
+    
+    with self.get_object_mock:
+      response = self.page_oembed.response(
+        request, query, max_width=600, max_height=None, pk=123, page=1
+      )
+    
+    # Check response properties
+    self.assertEqual(response["version"], "1.0")
+    self.assertEqual(response["type"], "rich")
+    self.assertEqual(response["title"], "Test Document")
+    self.assertEqual(response["width"], 600)
+    self.assertEqual(response["height"], 400)
+    self.assertEqual(
+      response["html"],
+      f'<iframe src="{settings.DOCCLOUD_EMBED_URL}/documents/123/?responsive=1#document/p1" title="Test Document (Hosted by DocumentCloud)" width="600" height="400" style="border: 1px solid #aaa; width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;" sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"></iframe>' # pylint:disable=line-too-long
+    )
+    
+  def test_page_oembed_get_dimensions(self):
+    """Test the get_dimensions method of PageOEmbed"""
+    # Test with max_width less than default
+    width, height = self.page_oembed.get_dimensions(self.document, 500, None)
+    self.assertEqual(width, 500)
+    self.assertEqual(height, 333)  
+    
+    # Test with max_width greater than default
+    width, height = self.page_oembed.get_dimensions(self.document, 800, None)
+    self.assertEqual(height, 533)  # Should be calculated based on aspect ratio
+    
+    # Test with no max dimensions
+    width, height = self.page_oembed.get_dimensions(self.document, None, None)
+    self.assertEqual(width, 800)  # Should be default
+    self.assertEqual(height, 533)  # Should be calculated based on aspect ratio
+
+  def test_page_oembed_get_context(self):
+    """Test the get_context method of PageOEmbed"""
+    query = Query("param=value")
+    extra = {"width": 600, "height": 400, "style": ""}
+    
+    context = self.page_oembed.get_context(self.document, query, extra, page=2)
+    
+    expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?param=value#document/p2"
+    self.assertEqual(context["src"], expected_src)
+    self.assertEqual(context["width"], 600)
+    self.assertEqual(context["height"], 400)
+    self.assertEqual(context["style"], "")

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -2,9 +2,110 @@ from django.conf import settings
 from django.test import RequestFactory, TestCase
 from unittest import mock
 from documentcloud.documents.models import Document
-from documentcloud.documents.oembed import PageOEmbed
+from documentcloud.documents.oembed import DocumentOEmbed, PageOEmbed
 from documentcloud.oembed.utils import Query
 
+class DocumentOEmbedTest(TestCase):
+  def setUp(self):
+    self.factory = RequestFactory()
+    self.user = mock.MagicMock()
+    self.document = mock.MagicMock(spec=Document)
+    self.document.title = "Test Document"
+    self.document.aspect_ratio = 1.5
+    self.document.get_absolute_url.return_value = "/documents/123/"
+    
+    # Mock the Document manager
+    self.document_queryset = mock.MagicMock()
+    self.document_queryset.get_viewable.return_value = self.document_queryset
+    Document.objects = self.document_queryset
+    
+    # Create a DocumentOEmbed instance
+    self.document_oembed = DocumentOEmbed()
+    
+    # Mock get_object_or_404
+    self.get_object_mock = mock.patch(
+      "documentcloud.documents.oembed.get_object_or_404", 
+      return_value=self.document
+    )
+
+  def test_document_oembed_response(self):
+    """Test the response method of DocumentOEmbed"""
+    request = self.factory.get("/oembed/")
+    request.user = self.user
+    query = Query("responsive=1")
+    
+    with self.get_object_mock:
+      response = self.document_oembed.response(
+        request, query, max_width=600, max_height=None, pk=123
+      )
+    
+    # Check response properties
+    self.assertEqual(response["version"], "1.0")
+    self.assertEqual(response["type"], "rich")
+    self.assertEqual(response["title"], "Test Document")
+    self.assertEqual(response["width"], 600)
+    self.assertEqual(response["height"], 400)
+    
+    # Check that the response contains an iframe with expected attributes
+    self.assertIn('<iframe src="', response["html"])
+    self.assertIn(f'{settings.DOCCLOUD_EMBED_URL}/documents/123/?responsive=1', response["html"])
+    self.assertIn('title="Test Document (Hosted by DocumentCloud)"', response["html"])
+    self.assertIn('width="600" height="400"', response["html"])
+    self.assertIn('style="border: 1px solid #aaa; width: 100%; height: 800px;', response["html"])
+    self.assertIn('sandbox="allow-scripts allow-same-origin allow-popups allow-forms', response["html"])
+    
+  def test_document_oembed_get_dimensions(self):
+    """Test the get_dimensions method of DocumentOEmbed"""
+    # Test with both max_width and max_height - should preserve both dimensions
+    width, height = self.document_oembed.get_dimensions(self.document, 600, 500)
+    self.assertEqual(width, 600)
+    self.assertEqual(height, 500)
+    
+    # Test with max_width less than default
+    width, height = self.document_oembed.get_dimensions(self.document, 500, None)
+    self.assertEqual(width, 500)
+    self.assertEqual(height, 333)  # 500/1.5 = 333.33...
+    
+    # Test with only max_height
+    width, height = self.document_oembed.get_dimensions(self.document, None, 450)
+    self.assertEqual(width, 675)  # 450*1.5 = 675
+    self.assertEqual(height, 450)
+    
+    # Test with no max dimensions
+    width, height = self.document_oembed.get_dimensions(self.document, None, None)
+    self.assertEqual(width, 800)  # Should be default
+    self.assertEqual(height, 533)  # 800/1.5 = 533.33...
+
+  def test_document_oembed_get_context(self):
+    """Test the get_context method of DocumentOEmbed"""
+    query = Query("param=value")
+    extra = {"width": 600, "height": 400, "style": ""}
+    
+    context = self.document_oembed.get_context(self.document, query, extra)
+    
+    expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?param=value"
+    self.assertEqual(context["src"], expected_src)
+    self.assertEqual(context["width"], 600)
+    self.assertEqual(context["height"], 400)
+    self.assertEqual(context["style"], "")
+    
+  def test_document_oembed_get_style(self):
+    """Test the get_style method of DocumentOEmbed"""
+    # Test responsive with no max dimensions
+    style = self.document_oembed.get_style(True, None, None)
+    self.assertEqual(style, " width: 100%; height: 800px; height: calc(100vh - 100px);")
+    
+    # Test with max_width only
+    style = self.document_oembed.get_style(True, 600, None)
+    self.assertEqual(style, " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;")
+    
+    # Test with max_height only
+    style = self.document_oembed.get_style(True, None, 400)
+    self.assertEqual(style, " width: 100%; height: 800px; height: calc(100vh - 100px); max-height: 400px;")
+    
+    # Test with both max dimensions
+    style = self.document_oembed.get_style(True, 600, 400)
+    self.assertEqual(style, " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px; max-height: 400px;")
 
 class PageOEmbedTest(TestCase):
   def setUp(self):
@@ -46,10 +147,14 @@ class PageOEmbedTest(TestCase):
     self.assertEqual(response["title"], "Test Document")
     self.assertEqual(response["width"], 600)
     self.assertEqual(response["height"], 400)
-    self.assertEqual(
-      response["html"],
-      f'<iframe src="{settings.DOCCLOUD_EMBED_URL}/documents/123/?responsive=1#document/p1" title="Test Document (Hosted by DocumentCloud)" width="600" height="400" style="border: 1px solid #aaa; width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;" sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"></iframe>' # pylint:disable=line-too-long
-    )
+    
+    # Check that the response contains an iframe with expected attributes
+    self.assertIn('<iframe src="', response["html"])
+    self.assertIn(f'{settings.DOCCLOUD_EMBED_URL}/documents/123/?responsive=1#document/p1', response["html"])
+    self.assertIn('title="Test Document (Hosted by DocumentCloud)"', response["html"])
+    self.assertIn('width="600" height="400"', response["html"])
+    self.assertIn('style="border: 1px solid #aaa; width: 100%; height: 800px;', response["html"])
+    self.assertIn('sandbox="allow-scripts allow-same-origin allow-popups allow-forms', response["html"])
     
   def test_page_oembed_get_dimensions(self):
     """Test the get_dimensions method of PageOEmbed"""

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -107,7 +107,9 @@ class DocumentOEmbedTest(TestCase):
 
         context = self.document_oembed.get_context(self.document, query, extra)
 
-        expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?param=value"
+        expected_src = (
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?param=value"
+        )
         self.assertEqual(context["src"], expected_src)
         self.assertEqual(context["width"], 600)
         self.assertEqual(context["height"], 400)

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -132,24 +132,21 @@ class TestDocumentOEmbed:
         # Test with max_width only
         style = self.document_oembed.get_style(600, None)
         assert (
-            style
-            == " width: 100%; height: 800px; height: calc(100vh - 100px); "
+            style == " width: 100%; height: 800px; height: calc(100vh - 100px); "
             "max-width: 600px;"
         )
 
         # Test with max_height only
         style = self.document_oembed.get_style(None, 400)
         assert (
-            style
-            == " width: 100%; height: 800px; height: calc(100vh - 100px); "
+            style == " width: 100%; height: 800px; height: calc(100vh - 100px); "
             "max-height: 400px;"
         )
 
         # Test with both max dimensions
         style = self.document_oembed.get_style(600, 400)
         assert (
-            style
-            == " width: 100%; height: 800px; height: calc(100vh - 100px); "
+            style == " width: 100%; height: 800px; height: calc(100vh - 100px); "
             "max-width: 600px; max-height: 400px;"
         )
 

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -1,9 +1,12 @@
 # Django
 from django.conf import settings
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory
 
 # Standard Library
 from unittest import mock
+
+# Third Party
+import pytest
 
 # DocumentCloud
 from documentcloud.documents.models import Document
@@ -11,9 +14,9 @@ from documentcloud.documents.oembed import DocumentOEmbed, NoteOEmbed, PageOEmbe
 from documentcloud.oembed.utils import Query
 
 
-class DocumentOEmbedTest(TestCase):
-    # pylint: disable=too-many-instance-attributes
-    def setUp(self):
+class TestDocumentOEmbed:
+    @pytest.fixture(autouse=True)
+    def setup(self):
         self.factory = RequestFactory()
         self.user = mock.MagicMock()
         self.document = mock.MagicMock(spec=Document)
@@ -41,11 +44,11 @@ class DocumentOEmbedTest(TestCase):
             return_value=self.document,
         )
         self.mock_get_object = self.get_object_patcher.start()
-
-    def tearDown(self):
-        # Restore original objects
+        
+        yield
+        
+        # Teardown
         Document.objects = self.original_objects
-        # Stop all patches
         self.get_object_patcher.stop()
 
     def test_document_oembed_response(self):
@@ -59,52 +62,41 @@ class DocumentOEmbedTest(TestCase):
         )
 
         # Check response properties
-        self.assertEqual(response["version"], "1.0")
-        self.assertEqual(response["type"], "rich")
-        self.assertEqual(response["title"], "Test Document")
-        self.assertEqual(response["width"], 600)
-        self.assertEqual(response["height"], 400)
+        assert response["version"] == "1.0"
+        assert response["type"] == "rich"
+        assert response["title"] == "Test Document"
+        assert response["width"] == 600
+        assert response["height"] == 400
 
         # Check that the response contains an iframe with expected attributes
-        self.assertIn('<iframe src="', response["html"])
-        self.assertIn(
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?responsive=1",
-            response["html"],
-        )
-        self.assertIn(
-            'title="Test Document (Hosted by DocumentCloud)"', response["html"]
-        )
-        self.assertIn('width="600" height="400"', response["html"])
-        self.assertIn(
-            'style="border: 1px solid #aaa; width: 100%; height: 800px;',
-            response["html"],
-        )
-        self.assertIn(
-            'sandbox="allow-scripts allow-same-origin allow-popups allow-forms',
-            response["html"],
-        )
+        assert '<iframe src="' in response["html"]
+        assert f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?responsive=1" in response["html"]
+        assert 'title="Test Document (Hosted by DocumentCloud)"' in response["html"]
+        assert 'width="600" height="400"' in response["html"]
+        assert 'style="border: 1px solid #aaa; width: 100%; height: 800px;' in response["html"]
+        assert 'sandbox="allow-scripts allow-same-origin allow-popups allow-forms' in response["html"]
 
     def test_document_oembed_get_dimensions(self):
         """Test the get_dimensions method of DocumentOEmbed"""
         # Test with both max_width and max_height - should preserve both dimensions
         width, height = self.document_oembed.get_dimensions(self.document, 600, 500)
-        self.assertEqual(width, 600)
-        self.assertEqual(height, 500)
+        assert width == 600
+        assert height == 500
 
         # Test with max_width less than default
         width, height = self.document_oembed.get_dimensions(self.document, 500, None)
-        self.assertEqual(width, 500)
-        self.assertEqual(height, 333)  # 500/1.5 = 333.33...
+        assert width == 500
+        assert height == 333  # 500/1.5 = 333.33...
 
         # Test with only max_height
         width, height = self.document_oembed.get_dimensions(self.document, None, 450)
-        self.assertEqual(width, 675)  # 450*1.5 = 675
-        self.assertEqual(height, 450)
+        assert width == 675  # 450*1.5 = 675
+        assert height == 450
 
         # Test with no max dimensions
         width, height = self.document_oembed.get_dimensions(self.document, None, None)
-        self.assertEqual(width, 800)  # Should be default
-        self.assertEqual(height, 533)  # 800/1.5 = 533.33...
+        assert width == 800  # Should be default
+        assert height == 533  # 800/1.5 = 533.33...
 
     def test_document_oembed_get_context(self):
         """Test the get_context method of DocumentOEmbed"""
@@ -113,47 +105,34 @@ class DocumentOEmbedTest(TestCase):
 
         context = self.document_oembed.get_context(self.document, query, extra)
 
-        expected_src = (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?param=value"
-        )
-        self.assertEqual(context["src"], expected_src)
-        self.assertEqual(context["width"], 600)
-        self.assertEqual(context["height"], 400)
-        self.assertEqual(context["style"], "")
+        expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?param=value"
+        assert context["src"] == expected_src
+        assert context["width"] == 600
+        assert context["height"] == 400
+        assert context["style"] == ""
 
     def test_document_oembed_get_style(self):
         """Test the get_style method of DocumentOEmbed"""
         # Test responsive with no max dimensions
         style = self.document_oembed.get_style(None, None)
-        self.assertEqual(
-            style, " width: 100%; height: 800px; height: calc(100vh - 100px);"
-        )
+        assert style == " width: 100%; height: 800px; height: calc(100vh - 100px);"
 
         # Test with max_width only
         style = self.document_oembed.get_style(600, None)
-        self.assertEqual(
-            style,
-            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;",  # pylint: disable=line-too-long
-        )
+        assert style == " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;"
 
         # Test with max_height only
         style = self.document_oembed.get_style(None, 400)
-        self.assertEqual(
-            style,
-            " width: 100%; height: 800px; height: calc(100vh - 100px); max-height: 400px;",  # pylint: disable=line-too-long
-        )
+        assert style == " width: 100%; height: 800px; height: calc(100vh - 100px); max-height: 400px;"
 
         # Test with both max dimensions
         style = self.document_oembed.get_style(600, 400)
-        self.assertEqual(
-            style,
-            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px; max-height: 400px;",  # pylint: disable=line-too-long
-        )
+        assert style == " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px; max-height: 400px;"
 
 
-class PageOEmbedTest(TestCase):
-    # pylint: disable=too-many-instance-attributes
-    def setUp(self):
+class TestPageOEmbed:
+    @pytest.fixture(autouse=True)
+    def setup(self):
         self.factory = RequestFactory()
         self.user = mock.MagicMock()
         self.document = mock.MagicMock(spec=Document)
@@ -181,11 +160,11 @@ class PageOEmbedTest(TestCase):
             return_value=self.document,
         )
         self.mock_get_object = self.get_object_patcher.start()
-
-    def tearDown(self):
-        # Restore original objects
+        
+        yield
+        
+        # Teardown
         Document.objects = self.original_objects
-        # Stop all patches
         self.get_object_patcher.stop()
 
     def test_page_oembed_response(self):
@@ -199,46 +178,35 @@ class PageOEmbedTest(TestCase):
         )
 
         # Check response properties
-        self.assertEqual(response["version"], "1.0")
-        self.assertEqual(response["type"], "rich")
-        self.assertEqual(response["title"], "Test Document")
-        self.assertEqual(response["width"], 600)
-        self.assertEqual(response["height"], 400)
+        assert response["version"] == "1.0"
+        assert response["type"] == "rich"
+        assert response["title"] == "Test Document"
+        assert response["width"] == 600
+        assert response["height"] == 400
 
         # Check that the response contains an iframe with expected attributes
-        self.assertIn('<iframe src="', response["html"])
-        self.assertIn(
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1/?responsive=1",
-            response["html"],
-        )
-        self.assertIn(
-            'title="Test Document (Hosted by DocumentCloud)"', response["html"]
-        )
-        self.assertIn('width="600" height="400"', response["html"])
-        self.assertIn(
-            'style="border: 1px solid #aaa; width: 100%; height: 800px;',
-            response["html"],
-        )
-        self.assertIn(
-            'sandbox="allow-scripts allow-same-origin allow-popups allow-forms',
-            response["html"],
-        )
+        assert '<iframe src="' in response["html"]
+        assert f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1/?responsive=1" in response["html"]
+        assert 'title="Test Document (Hosted by DocumentCloud)"' in response["html"]
+        assert 'width="600" height="400"' in response["html"]
+        assert 'style="border: 1px solid #aaa; width: 100%; height: 800px;' in response["html"]
+        assert 'sandbox="allow-scripts allow-same-origin allow-popups allow-forms' in response["html"]
 
     def test_page_oembed_get_dimensions(self):
         """Test the get_dimensions method of PageOEmbed"""
         # Test with max_width less than default
         width, height = self.page_oembed.get_dimensions(self.document, 500, None)
-        self.assertEqual(width, 500)
-        self.assertEqual(height, 333)
+        assert width == 500
+        assert height == 333
 
         # Test with max_width greater than default
         width, height = self.page_oembed.get_dimensions(self.document, 800, None)
-        self.assertEqual(height, 533)  # Should be calculated based on aspect ratio
+        assert height == 533  # Should be calculated based on aspect ratio
 
         # Test with no max dimensions
         width, height = self.page_oembed.get_dimensions(self.document, None, None)
-        self.assertEqual(width, 800)  # Should be default
-        self.assertEqual(height, 533)  # Should be calculated based on aspect ratio
+        assert width == 800  # Should be default
+        assert height == 533  # Should be calculated based on aspect ratio
 
     def test_page_oembed_get_context(self):
         """Test the get_context method of PageOEmbed"""
@@ -247,18 +215,16 @@ class PageOEmbedTest(TestCase):
 
         context = self.page_oembed.get_context(self.document, query, extra, page=2)
 
-        expected_src = (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/2/?param=value"
-        )
-        self.assertEqual(context["src"], expected_src)
-        self.assertEqual(context["width"], 600)
-        self.assertEqual(context["height"], 400)
-        self.assertEqual(context["style"], "")
+        expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/2/?param=value"
+        assert context["src"] == expected_src
+        assert context["width"] == 600
+        assert context["height"] == 400
+        assert context["style"] == ""
 
 
-class NoteOEmbedTest(TestCase):
-    # pylint: disable=too-many-instance-attributes
-    def setUp(self):
+class TestNoteOEmbed:
+    @pytest.fixture(autouse=True)
+    def setup(self):
         self.factory = RequestFactory()
         self.user = mock.MagicMock()
 
@@ -298,11 +264,11 @@ class NoteOEmbedTest(TestCase):
             side_effect=[self.document, self.note],
         )
         self.mock_get_object = self.get_object_patcher.start()
-
-    def tearDown(self):
-        # Restore original objects
+        
+        yield
+        
+        # Teardown
         Document.objects = self.original_objects
-        # Stop all patches
         self.get_object_patcher.stop()
 
     def test_note_oembed_response(self):
@@ -316,20 +282,14 @@ class NoteOEmbedTest(TestCase):
         )
 
         # Check response properties
-        self.assertEqual(response["version"], "1.0")
-        self.assertEqual(response["type"], "rich")
-        self.assertEqual(response["title"], "Test Note")
+        assert response["version"] == "1.0"
+        assert response["type"] == "rich"
+        assert response["title"] == "Test Note"
 
         # Check that the response contains an iframe with expected attributes
-        self.assertIn('<iframe src="', response["html"])
-        self.assertIn(
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?responsive=1",  # pylint: disable=line-too-long
-            response["html"],
-        )
-        self.assertIn('title="Test Note (Hosted by DocumentCloud)"', response["html"])
-        self.assertIn('width="100%" height="500px"', response["html"])
-        self.assertIn('style="border: 1px solid #aaa;', response["html"])
-        self.assertIn(
-            'sandbox="allow-scripts allow-same-origin allow-popups allow-forms',
-            response["html"],
-        )
+        assert '<iframe src="' in response["html"]
+        assert f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?responsive=1" in response["html"]
+        assert 'title="Test Note (Hosted by DocumentCloud)"' in response["html"]
+        assert 'width="100%" height="500px"' in response["html"]
+        assert 'style="border: 1px solid #aaa;' in response["html"]
+        assert 'sandbox="allow-scripts allow-same-origin allow-popups allow-forms' in response["html"]

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -13,8 +13,11 @@ class DocumentOEmbedTest(TestCase):
         self.document = mock.MagicMock(spec=Document)
         self.document.title = "Test Document"
         self.document.aspect_ratio = 1.5
-        self.document.get_absolute_url.return_value = "/documents/123/"
+        self.document.slug = "test-document"
         self.document.pk = 123
+        self.document.get_absolute_url.return_value = (
+            f"/documents/{self.document.pk}-{self.document.slug}/"
+        )
 
         # Mock the Document manager
         self.document_queryset = mock.MagicMock()
@@ -59,7 +62,7 @@ class DocumentOEmbedTest(TestCase):
         # Check that the response contains an iframe with expected attributes
         self.assertIn('<iframe src="', response["html"])
         self.assertIn(
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?responsive=1",
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?responsive=1",
             response["html"],
         )
         self.assertIn(
@@ -104,7 +107,7 @@ class DocumentOEmbedTest(TestCase):
 
         context = self.document_oembed.get_context(self.document, query, extra)
 
-        expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?param=value"
+        expected_src = f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?param=value"
         self.assertEqual(context["src"], expected_src)
         self.assertEqual(context["width"], 600)
         self.assertEqual(context["height"], 400)
@@ -146,9 +149,12 @@ class PageOEmbedTest(TestCase):
         self.user = mock.MagicMock()
         self.document = mock.MagicMock(spec=Document)
         self.document.pk = 123
+        self.document.slug = "test-document"
         self.document.title = "Test Document"
         self.document.aspect_ratio = 1.5
-        self.document.get_absolute_url.return_value = "/documents/123/"
+        self.document.get_absolute_url.return_value = (
+            f"/documents/{self.document.pk}-{self.document.slug}/"
+        )
 
         # Mock the Document manager
         self.document_queryset = mock.MagicMock()
@@ -193,7 +199,7 @@ class PageOEmbedTest(TestCase):
         # Check that the response contains an iframe with expected attributes
         self.assertIn('<iframe src="', response["html"])
         self.assertIn(
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1?responsive=1",
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1/?responsive=1",
             response["html"],
         )
         self.assertIn(
@@ -233,7 +239,7 @@ class PageOEmbedTest(TestCase):
         context = self.page_oembed.get_context(self.document, query, extra, page=2)
 
         expected_src = (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/2?param=value"
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/2/?param=value"
         )
         self.assertEqual(context["src"], expected_src)
         self.assertEqual(context["width"], 600)
@@ -249,8 +255,11 @@ class NoteOEmbedTest(TestCase):
         # Mock the Document
         self.document = mock.MagicMock(spec=Document)
         self.document.title = "Test Document"
-        self.document.get_absolute_url.return_value = "/documents/123/"
+        self.document.slug = "test-document"
         self.document.pk = 123
+        self.document.get_absolute_url.return_value = (
+            f"/documents/{self.document.pk}-{self.document.slug}/"
+        )
 
         # Mock the Note
         self.note = mock.MagicMock()
@@ -304,7 +313,7 @@ class NoteOEmbedTest(TestCase):
         # Check that the response contains an iframe with expected attributes
         self.assertIn('<iframe src="', response["html"])
         self.assertIn(
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456?responsive=1",
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?responsive=1",
             response["html"],
         )
         self.assertIn('title="Test Note (Hosted by DocumentCloud)"', response["html"])

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -7,6 +7,7 @@ from documentcloud.oembed.utils import Query
 
 
 class DocumentOEmbedTest(TestCase):
+    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.factory = RequestFactory()
         self.user = mock.MagicMock()
@@ -118,34 +119,35 @@ class DocumentOEmbedTest(TestCase):
     def test_document_oembed_get_style(self):
         """Test the get_style method of DocumentOEmbed"""
         # Test responsive with no max dimensions
-        style = self.document_oembed.get_style(True, None, None)
+        style = self.document_oembed.get_style(None, None)
         self.assertEqual(
             style, " width: 100%; height: 800px; height: calc(100vh - 100px);"
         )
 
         # Test with max_width only
-        style = self.document_oembed.get_style(True, 600, None)
+        style = self.document_oembed.get_style(600, None)
         self.assertEqual(
             style,
-            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;",
+            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px;", # pylint: disable=line-too-long
         )
 
         # Test with max_height only
-        style = self.document_oembed.get_style(True, None, 400)
+        style = self.document_oembed.get_style(None, 400)
         self.assertEqual(
             style,
-            " width: 100%; height: 800px; height: calc(100vh - 100px); max-height: 400px;",
+            " width: 100%; height: 800px; height: calc(100vh - 100px); max-height: 400px;", # pylint: disable=line-too-long
         )
 
         # Test with both max dimensions
-        style = self.document_oembed.get_style(True, 600, 400)
+        style = self.document_oembed.get_style(600, 400)
         self.assertEqual(
             style,
-            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px; max-height: 400px;",
+            " width: 100%; height: 800px; height: calc(100vh - 100px); max-width: 600px; max-height: 400px;", # pylint: disable=line-too-long
         )
 
 
 class PageOEmbedTest(TestCase):
+    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.factory = RequestFactory()
         self.user = mock.MagicMock()
@@ -250,6 +252,7 @@ class PageOEmbedTest(TestCase):
 
 
 class NoteOEmbedTest(TestCase):
+    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         self.factory = RequestFactory()
         self.user = mock.MagicMock()
@@ -315,7 +318,7 @@ class NoteOEmbedTest(TestCase):
         # Check that the response contains an iframe with expected attributes
         self.assertIn('<iframe src="', response["html"])
         self.assertIn(
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?responsive=1",
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?responsive=1", # pylint: disable=line-too-long
             response["html"],
         )
         self.assertIn('title="Test Note (Hosted by DocumentCloud)"', response["html"])

--- a/documentcloud/oembed/utils.py
+++ b/documentcloud/oembed/utils.py
@@ -1,23 +1,26 @@
 from urllib.parse import parse_qs
 
+
 class Query:
     """Class to handle query string parameters for OEmbed requests."""
-    
+
     def __init__(self, qs):
         """Initialize with a query string."""
         self.query_string = qs
         self.params = {}
-        
+
         if qs:
             # Parse the query string into a dictionary
             parsed = parse_qs(qs)
             # Convert lists to single values for easier access
-            self.params = {k: v[0] if v and len(v) == 1 else v for k, v in parsed.items()}
-    
+            self.params = {
+                k: v[0] if v and len(v) == 1 else v for k, v in parsed.items()
+            }
+
     def __bool__(self):
         """Return True if there are parameters."""
         return bool(self.params)
-    
+
     def __str__(self):
         """Convert back to query string for URL construction."""
         return self.query_string

--- a/documentcloud/oembed/utils.py
+++ b/documentcloud/oembed/utils.py
@@ -1,3 +1,4 @@
+# Standard Library
 from urllib.parse import parse_qs
 
 

--- a/documentcloud/oembed/utils.py
+++ b/documentcloud/oembed/utils.py
@@ -1,0 +1,23 @@
+from urllib.parse import parse_qs
+
+class Query:
+    """Class to handle query string parameters for OEmbed requests."""
+    
+    def __init__(self, qs):
+        """Initialize with a query string."""
+        self.query_string = qs
+        self.params = {}
+        
+        if qs:
+            # Parse the query string into a dictionary
+            parsed = parse_qs(qs)
+            # Convert lists to single values for easier access
+            self.params = {k: v[0] if v and len(v) == 1 else v for k, v in parsed.items()}
+    
+    def __bool__(self):
+        """Return True if there are parameters."""
+        return bool(self.params)
+    
+    def __str__(self):
+        """Convert back to query string for URL construction."""
+        return self.query_string

--- a/documentcloud/templates/oembed/note.html
+++ b/documentcloud/templates/oembed/note.html
@@ -1,8 +1,1 @@
-<div id="DC-note-{{ pk }}" class="DC-embed DC-embed-note DC-note-container" style="max-width:{{ width }}px"></div>
-<script src="{{ loader_src }}"></script>
-<script>
-  dc.embed.loadNote('{{ note_src }}');
-</script>
-<noscript>
-  <a href="{{ note_html_src }}">View note</a>
-</noscript>
+<iframe src="{{ src }}" title="{{ title }} (Hosted by DocumentCloud)" width="100%" height="500px" style="border: 1px solid #aaa;{{ style }}" sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"></iframe>

--- a/documentcloud/templates/oembed/page.html
+++ b/documentcloud/templates/oembed/page.html
@@ -1,10 +1,1 @@
-<div class="DC-embed" style="font-family: Source Sans Pro, Avenir Next, Avenir, Helvetica Neue, Helvetica, Arial, sans-serif; max-width: {{ width }}px; background: rgb(244, 244, 244); padding: 18px 20px; box-sizing: border-box; border: solid 1px gainsboro; border-radius: 3px;">
-  <div style="font-size:14px;line-height:18px;">
-    Page {{ page }} of <a class="DC-embed-resource" style="color:#5a76a0;text-decoration:underline;" href="{{ page_url }}" title="View entire {{ title }} on DocumentCloud in new window or tab" target="_blank"> {{ title }}</a>
-  </div>
-  <img src="//{{ img_url }}" alt="Page {{ page }} of {{ title }}" style="max-width:100%;height:auto;margin:0.5em 0;border:1px solid #ccc;-webkit-box-sizing:border-box;box-sizing:border-box;clear:both" />
-  <div style="font-size:14px;line-height:18px;text-align:center">
-    Contributed to <a href="{{ app_url }}" title="Go to DocumentCloud in new window or tab" target="_blank" style="color:#5a76a0;text-decoration:underline;font-weight:700;font-family:Gotham,inherit,sans-serif;color:inherit;text-decoration:none">DocumentCloud</a> by {{ user_org_string }} &bull; <a style="color: #5a76a0; text-decoration: underline;" href="{{ page_url }}" title="View entire {{ title }} on DocumentCloud in new window or tab" target="_blank">View document</a> or <a style="color: #5a76a0; text-decoration: underline;" href="{{ text_url }}" title="Read the text of page {{ page }} of {{ title }} on DocumentCloud in new window or tab" target="_blank">read text</a>
-  </div>
-</div>
-<script src="{{ enhance_src }}"></script>
+<iframe src="{{ src }}" title="{{ title }} (Hosted by DocumentCloud)" width="{{ width }}" height="{{ height }}" style="border: 1px solid #aaa;{{ style }}" sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"></iframe>


### PR DESCRIPTION
Closes #299 

This updates our templates for `oembed/page.html` and `oembed/note.html` to use our contemporary `iframe` approach for embeds.

It also adds tests to assert that we're rendering oEmbed responses as we expect.

Finally, I removed `apt-get upgrade` from the Dockerfile. It was crashing on my system every time I tried to build the Django container—removing this step solved the crashing, and [some research shows](https://stackoverflow.com/a/63901529) it's a better practice to use the image you're pulling as-is.

**Previewed on staging:**
- [Note oEmbed response](https://api.muckcloud.com/api/oembed/?url=https%3A%2F%2Fwww.staging.documentcloud.org%2Fdocuments%2F1845793-seeking-water-justice-2010%2F%23document%2Fp6%2Fa213242)
- [Page oEmbed response](https://api.muckcloud.com/api/oembed/?url=https%3A%2F%2Fwww.staging.documentcloud.org%2Fdocuments%2F451349-christy-clark-donor-list%23document%2Fp1)