### PR TITLE
Pass oEmbed query parameters through to the embed iFrame

### DIFF
--- a/documentcloud/documents/oembed.py
+++ b/documentcloud/documents/oembed.py
@@ -48,8 +48,9 @@ class DocumentOEmbed(RichOEmbed):
 
     def get_context(self, document, query, extra, **kwargs):
         src = settings.DOCCLOUD_EMBED_URL + document.get_absolute_url()
+        src = f"{src}?embed=1"
         if query:
-            src = f"{src}?{query}"
+            src = f"{src}&{query}"
         return {"src": src, **extra}
 
     def get_dimensions(self, document, max_width, max_height):
@@ -96,8 +97,9 @@ class PageOEmbed(DocumentOEmbed):
     def get_context(self, document, query, extra, **kwargs):
         page = int(kwargs["page"])
         src = f"{settings.DOCCLOUD_EMBED_URL}/documents/{document.pk}/pages/{page}/"
+        src = f"{src}?embed=1"
         if query:
-            src = f"{src}?{query}"
+            src = f"{src}&{query}"
         return {
             "src": src,
             **extra,
@@ -137,8 +139,9 @@ class NoteOEmbed(RichOEmbed):
             f"{settings.DOCCLOUD_EMBED_URL}/documents/"
             f"{document.pk}/annotations/{note.pk}/"
         )
+        src = f"{src}?embed=1"
         if query:
-            src = f"{src}?{query}"
+            src = f"{src}&{query}"
         context = {
             "src": src,
             "title": note.title,

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -72,18 +72,35 @@ class TestDocumentOEmbed:
         # Check that the response contains an iframe with expected attributes
         assert '<iframe src="' in response["html"]
         assert (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?responsive=1"
-            in response["html"]
-        )
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?embed=1&amp;responsive=1"
+        ) in response["html"]
         assert 'title="Test Document (Hosted by DocumentCloud)"' in response["html"]
         assert 'width="600" height="400"' in response["html"]
         assert (
             'style="border: 1px solid #aaa; width: 100%; height: 800px;'
-            in response["html"]
-        )
+        ) in response["html"]
         assert (
             'sandbox="allow-scripts allow-same-origin allow-popups allow-forms'
             in response["html"]
+        )
+
+    def test_document_oembed_query_passthrough(self):
+        """Test that query parameters are passed through to the iFrame src"""
+        request = self.factory.get("/oembed/")
+        request.user = self.user
+        query = Query("responsive=1&fullscreen=1&title=0")
+
+        with self.get_object_mock:
+            response = self.document_oembed.response(
+                request, query, max_width=600, max_height=None, pk=123
+            )
+
+        # Check that the response contains an iframe with expected attributes
+        self.assertIn('<iframe src="', response["html"])
+        # Since the text is HTML, we need to encode the ampersands
+        self.assertIn(
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?embed=1&amp;responsive=1&amp;fullscreen=1&amp;title=0",
+            response["html"],
         )
 
     def test_document_oembed_get_dimensions(self):
@@ -116,7 +133,7 @@ class TestDocumentOEmbed:
         context = self.document_oembed.get_context(self.document, query, extra)
 
         expected_src = (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123-test-document/?param=value"
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?embed=1&param=value"
         )
         assert context["src"] == expected_src
         assert context["width"] == 600
@@ -209,9 +226,8 @@ class TestPageOEmbed:
         # Check that the response contains an iframe with expected attributes
         assert '<iframe src="' in response["html"]
         assert (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1/?responsive=1"
-            in response["html"]
-        )
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1?embed=1&amp;responsive=1",
+        ) in response["html"]
         assert 'title="Test Document (Hosted by DocumentCloud)"' in response["html"]
         assert 'width="600" height="400"' in response["html"]
         assert (
@@ -247,7 +263,7 @@ class TestPageOEmbed:
         context = self.page_oembed.get_context(self.document, query, extra, page=2)
 
         expected_src = (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/2/?param=value"
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/2/?embed=1&param=value"
         )
         assert context["src"] == expected_src
         assert context["width"] == 600
@@ -323,9 +339,8 @@ class TestNoteOEmbed:
         # Check that the response contains an iframe with expected attributes
         assert '<iframe src="' in response["html"]
         assert (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?responsive=1"
-            in response["html"]
-        )
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?embed=1&amp;responsive=1"
+        ) in response["html"]
         assert 'title="Test Note (Hosted by DocumentCloud)"' in response["html"]
         assert 'width="100%" height="500px"' in response["html"]
         assert 'style="border: 1px solid #aaa;' in response["html"]

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -72,7 +72,9 @@ class TestDocumentOEmbed:
         # Check that the response contains an iframe with expected attributes
         assert '<iframe src="' in response["html"]
         assert (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?embed=1&amp;responsive=1"
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/"
+            f"{self.document.pk}-{self.document.slug}/"
+            "?embed=1&amp;responsive=1"
         ) in response["html"]
         assert 'title="Test Document (Hosted by DocumentCloud)"' in response["html"]
         assert 'width="600" height="400"' in response["html"]
@@ -90,18 +92,18 @@ class TestDocumentOEmbed:
         request.user = self.user
         query = Query("responsive=1&fullscreen=1&title=0")
 
-        with self.get_object_mock:
-            response = self.document_oembed.response(
-                request, query, max_width=600, max_height=None, pk=123
-            )
+        response = self.document_oembed.response(
+            request, query, max_width=600, max_height=None, pk=123
+        )
 
         # Check that the response contains an iframe with expected attributes
-        self.assertIn('<iframe src="', response["html"])
+        assert '<iframe src="' in response["html"]
         # Since the text is HTML, we need to encode the ampersands
-        self.assertIn(
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?embed=1&amp;responsive=1&amp;fullscreen=1&amp;title=0",
-            response["html"],
-        )
+        assert (
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/"
+            f"{self.document.pk}-{self.document.slug}/"
+            "?embed=1&amp;responsive=1&amp;fullscreen=1&amp;title=0"
+        ) in response["html"]
 
     def test_document_oembed_get_dimensions(self):
         """Test the get_dimensions method of DocumentOEmbed"""
@@ -133,7 +135,9 @@ class TestDocumentOEmbed:
         context = self.document_oembed.get_context(self.document, query, extra)
 
         expected_src = (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/?embed=1&param=value"
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/"
+            f"{self.document.pk}-{self.document.slug}/"
+            "?embed=1&param=value"
         )
         assert context["src"] == expected_src
         assert context["width"] == 600
@@ -226,7 +230,8 @@ class TestPageOEmbed:
         # Check that the response contains an iframe with expected attributes
         assert '<iframe src="' in response["html"]
         assert (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1?embed=1&amp;responsive=1",
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/pages/1/"
+            "?embed=1&amp;responsive=1"
         ) in response["html"]
         assert 'title="Test Document (Hosted by DocumentCloud)"' in response["html"]
         assert 'width="600" height="400"' in response["html"]
@@ -339,7 +344,8 @@ class TestNoteOEmbed:
         # Check that the response contains an iframe with expected attributes
         assert '<iframe src="' in response["html"]
         assert (
-            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/?embed=1&amp;responsive=1"
+            f"{settings.DOCCLOUD_EMBED_URL}/documents/123/annotations/456/"
+            "?embed=1&amp;responsive=1"
         ) in response["html"]
         assert 'title="Test Note (Hosted by DocumentCloud)"' in response["html"]
         assert 'width="100%" height="500px"' in response["html"]


### PR DESCRIPTION
Closes #300 

This adds tested functionality for ensuring every iframe `src` has `embed=1` applied, and that any query parameters provided in the `url` are passed through to the iframe `src`.

Needs testing on staging to ensure that `fullscreen` is passed through and properly supported.

Update: I'm suspecting that the fullscreen not appearing is a frontend issue with embed rendering, not an issue with parameter passthrough. See https://github.com/MuckRock/documentcloud-frontend/issues/1112