### PR TITLE
Adds ability to search keys and their corresponding values

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -29,12 +29,12 @@ from documentcloud.addons.views import (
 from documentcloud.core.views import FileServer, account_logout, mailgun
 from documentcloud.documents.views import (
     DataViewSet,
-    KeyViewSet,
-    KeyValueViewSet,
     DocumentErrorViewSet,
     DocumentViewSet,
     EntityDateViewSet,
     EntityViewSet as LegacyEntity2ViewSet,
+    KeyValueViewSet,
+    KeyViewSet,
     LegacyEntityViewSet,
     ModificationViewSet,
     NoteViewSet,

--- a/config/urls.py
+++ b/config/urls.py
@@ -29,6 +29,8 @@ from documentcloud.addons.views import (
 from documentcloud.core.views import FileServer, account_logout, mailgun
 from documentcloud.documents.views import (
     DataViewSet,
+    KeyViewSet,
+    KeyValueViewSet,
     DocumentErrorViewSet,
     DocumentViewSet,
     EntityDateViewSet,
@@ -69,7 +71,12 @@ router.register("addon_events", AddOnEventViewSet)
 router.register("entities", EntityViewSet, basename="entities")
 router.register("flatpages", FlatPageViewSet)
 router.register("statistics", StatisticsViewSet)
-
+router.register("documents/data/keys", KeyViewSet, basename="data-keys")
+router.register(
+    r"documents/data/keys/(?P<key>[^/]+)/values",
+    KeyValueViewSet,
+    basename="data-values",
+)
 
 documents_router = BulkNestedDefaultRouter(router, "documents", lookup="document")
 documents_router.register("notes", NoteViewSet)

--- a/documentcloud/documents/models/document.py
+++ b/documentcloud/documents/models/document.py
@@ -33,7 +33,6 @@ from documentcloud.documents.querysets import DocumentQuerySet
 
 logger = logging.getLogger(__name__)
 
-# pylint:disable = too-many-lines
 
 
 class Document(models.Model):

--- a/documentcloud/documents/models/document.py
+++ b/documentcloud/documents/models/document.py
@@ -34,7 +34,6 @@ from documentcloud.documents.querysets import DocumentQuerySet
 logger = logging.getLogger(__name__)
 
 
-
 class Document(models.Model):
     """A document uploaded to DocumentCloud"""
 


### PR DESCRIPTION
Limited to keys/values that appear on documents viewable to the user. 
Endpoints are:
/api/documents/data/keys/
/api/documents/data/keys/{key}/values/
Chose this demonstrate that we are searching across several documents' data fields. Can change this. 

Example of all keys visible to this user:
![AllKeysVisibletoUser](https://github.com/user-attachments/assets/456a8107-d9df-4bf0-afce-64d0a8912466)

Example of all values for a particular key (color) for this user:
![AllValuesforKeyColor](https://github.com/user-attachments/assets/12363ec4-5b34-4066-9c68-924fe0152f7a)

Can restrain further by providing a project ID. 
![FilterKeysbyProject](https://github.com/user-attachments/assets/d2e1858a-10e1-4c84-8ec0-d6470fe81214)

Similarly with values
![AllValuesforKeyColorFilteredByProject](https://github.com/user-attachments/assets/8b395cb0-a677-4da1-8d3b-77cb5114cd6e)

I had concerns about user provided key names so I used a regular expression to validate that the input is an alphanumeric. 