### PR TITLE
Allows fullscreen on document iFrames generated by the oEmbed API

### DIFF
--- a/documentcloud/templates/oembed/document.html
+++ b/documentcloud/templates/oembed/document.html
@@ -1,1 +1,1 @@
-<iframe src="{{ src }}" title="{{ title }} (Hosted by DocumentCloud)" width="{{ width }}" height="{{ height }}" style="border: 1px solid #aaa;{{ style }}" sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"></iframe>
+<iframe src="{{ src }}" title="{{ title }} (Hosted by DocumentCloud)" width="{{ width }}" height="{{ height }}" style="border: 1px solid #aaa;{{ style }}" allow="fullscreen" sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"></iframe>


### PR DESCRIPTION
Enables the `requestFullscreen` in the frame, which is required for our fullscreen action to appear.