### PR TITLE
Documentation fixes for document search and project creation

### DIFF
--- a/documentcloud/documents/models/document.py
+++ b/documentcloud/documents/models/document.py
@@ -33,8 +33,6 @@ from documentcloud.documents.querysets import DocumentQuerySet
 
 logger = logging.getLogger(__name__)
 
-# pylint:disable = too-many-lines
-
 
 class Document(models.Model):
     """A document uploaded to DocumentCloud"""

--- a/documentcloud/documents/views.py
+++ b/documentcloud/documents/views.py
@@ -1126,10 +1126,8 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
     @action(detail=False, methods=["get"])
     def search(self, request):
         """
-        Search across all documents on DocumentCloud with
-        full text search using Solr.
-        View our search documentation for a full parameter list:
-        https://www.documentcloud.org/help/search/
+        Search across all documents on DocumentCloud with full text search using Solr.
+        Consult our [search documentation](https://www.documentcloud.org/help/search/) for a full parameter list.
         This endpoint does return a full count, but does not provide a previous link.
         """
         if settings.SOLR_DISABLE_ANON and request.user.is_anonymous:
@@ -1176,8 +1174,7 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
         Search within a single document using Solr.
         This will return up to 25 text highlights
         per response page for your query.
-        View our search documentation for a full parameter list:
-        https://www.documentcloud.org/help/search/
+        Consult our [search documentation](https://www.documentcloud.org/help/search/) for a full parameter list.
         """
         if settings.SOLR_DISABLE_ANON and request.user.is_anonymous:
             return Response(

--- a/documentcloud/documents/views.py
+++ b/documentcloud/documents/views.py
@@ -573,6 +573,13 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
         ],
     )
     def list(self, request, *args, **kwargs):
+        """ List documents using Postgres. Although this endpoint offers
+            some similar filters to those on Solr, documents_list does not
+            support full text search of the document collection. 
+            For that, you are looking for documents_search across.
+            If you are looking for text search within a single document, 
+            you are looking for documents_search_within.
+        """
         return super().list(request, *args, **kwargs)
 
     @extend_schema(
@@ -1116,7 +1123,12 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
     @extend_schema(operation_id="documents_search_across")
     @action(detail=False, methods=["get"])
     def search(self, request):
-        """Search across all documents on DocumentCloud"""
+        """
+            Search across all documents on DocumentCloud with
+            full text search using Solr. 
+            View our search documentation for a full parameter list:
+            https://www.documentcloud.org/help/search/
+        """
         if settings.SOLR_DISABLE_ANON and request.user.is_anonymous:
             return Response(
                 {
@@ -1157,7 +1169,13 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
     @extend_schema(operation_id="documents_search_within_single_document")
     @action(detail=True, url_path="search", methods=["get"])
     def page_search(self, request, pk=None):
-        """Search within a single document"""
+        """
+            Search within a single document using Solr.
+            This will return up to 25 text highlights
+            per response page for your query. 
+            View our search documentation for a full parameter list:
+            https://www.documentcloud.org/help/search/
+        """
         if settings.SOLR_DISABLE_ANON and request.user.is_anonymous:
             return Response(
                 {

--- a/documentcloud/documents/views.py
+++ b/documentcloud/documents/views.py
@@ -576,12 +576,11 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
         """List documents with optional filters. This is not to be confused with search.
         This endpoint does not support full text search of the document collection.
         For that, you are looking for
-        [documents_search_across](https://api.www.documentcloud.org/api/schema/redoc/#tag/documents/operation/documents_search_across)
-        If you are looking for text search within a single document to return text highlights,
-        you are looking for
+        [documents_search_across](https://api.www.documentcloud.org/api/schema/redoc/#tag/documents/operation/documents_search_across).
+        If you are looking for text search within a single document to return text highlights, then
         [documents_search_within_single_document](https://api.www.documentcloud.org/api/schema/redoc/#tag/documents/operation/documents_search_within_single_document)
-        For performance reasons, this endpoint will not return a count
-        of all objects, only a link to next and previous responses.
+        is the correct endpoint. For performance reasons, this endpoint will not return a count of all objects,
+        only a link to next and previous.
         """
         return super().list(request, *args, **kwargs)
 

--- a/documentcloud/documents/views.py
+++ b/documentcloud/documents/views.py
@@ -573,11 +573,15 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
         ],
     )
     def list(self, request, *args, **kwargs):
-        """ List documents with optional filters using Postgres. This is not to be confused with search.
-            This endpoint does not support full text search of the document collection. 
-            For that, you are looking for documents_search across.
-            If you are looking for text search within a single document to return text highlights,
-            you are looking for documents_search_within.
+        """List documents with optional filters. This is not to be confused with search.
+        This endpoint does not support full text search of the document collection.
+        For that, you are looking for
+        [documents_search_across](https://api.www.documentcloud.org/api/schema/redoc/#tag/documents/operation/documents_search_across)
+        If you are looking for text search within a single document to return text highlights,
+        you are looking for
+        [documents_search_within_single_document](https://api.www.documentcloud.org/api/schema/redoc/#tag/documents/operation/documents_search_within_single_document)
+        For performance reasons, this endpoint will not return a count
+        of all objects, only a link to next and previous responses.
         """
         return super().list(request, *args, **kwargs)
 
@@ -1123,10 +1127,11 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
     @action(detail=False, methods=["get"])
     def search(self, request):
         """
-            Search across all documents on DocumentCloud with
-            full text search using Solr. 
-            View our search documentation for a full parameter list:
-            https://www.documentcloud.org/help/search/
+        Search across all documents on DocumentCloud with
+        full text search using Solr.
+        View our search documentation for a full parameter list:
+        https://www.documentcloud.org/help/search/
+        This endpoint does return a full count, but does not provide a previous link.
         """
         if settings.SOLR_DISABLE_ANON and request.user.is_anonymous:
             return Response(
@@ -1169,11 +1174,11 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
     @action(detail=True, url_path="search", methods=["get"])
     def page_search(self, request, pk=None):
         """
-            Search within a single document using Solr.
-            This will return up to 25 text highlights
-            per response page for your query. 
-            View our search documentation for a full parameter list:
-            https://www.documentcloud.org/help/search/
+        Search within a single document using Solr.
+        This will return up to 25 text highlights
+        per response page for your query.
+        View our search documentation for a full parameter list:
+        https://www.documentcloud.org/help/search/
         """
         if settings.SOLR_DISABLE_ANON and request.user.is_anonymous:
             return Response(

--- a/documentcloud/documents/views.py
+++ b/documentcloud/documents/views.py
@@ -573,11 +573,10 @@ class DocumentViewSet(BulkModelMixin, FlexFieldsModelViewSet):
         ],
     )
     def list(self, request, *args, **kwargs):
-        """ List documents using Postgres. Although this endpoint offers
-            some similar filters to those on Solr, documents_list does not
-            support full text search of the document collection. 
+        """ List documents with optional filters using Postgres. This is not to be confused with search.
+            This endpoint does not support full text search of the document collection. 
             For that, you are looking for documents_search across.
-            If you are looking for text search within a single document, 
+            If you are looking for text search within a single document to return text highlights,
             you are looking for documents_search_within.
         """
         return super().list(request, *args, **kwargs)

--- a/documentcloud/projects/views.py
+++ b/documentcloud/projects/views.py
@@ -94,7 +94,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
     )
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
-    
+
     @extend_schema(
         request={
             "application/json": {

--- a/documentcloud/projects/views.py
+++ b/documentcloud/projects/views.py
@@ -94,9 +94,29 @@ class ProjectViewSet(viewsets.ModelViewSet):
     )
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
-
+    
     @extend_schema(
-        request=ProjectSerializer,
+        request={
+            "application/json": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "Title of the project",
+                    },
+                    "description": {
+                        "type": "string",
+                        "maxLength": 1000,
+                        "description": "Optional description of the project",
+                    },
+                    "private": {
+                        "type": "boolean",
+                        "description": "Whether the project is private",
+                    },
+                },
+                "required": ["title"],
+            }
+        },
         responses={201: ProjectSerializer},
         examples=[
             OpenApiExample(


### PR DESCRIPTION
Document Solr search has a lot of differences from the postgres search fields and some subtleties that are hard to capture in DRF . In the old documentation for /api/documents/search and /api/documents/{document_pk}/search we point to the search documentation. I think this is a better approach than trying to build out the full documentation with DRF for these particular endpoints. 

I also make it explicit on list that it is not a full text search and that if they are looking for that to go to documents_search_across or the page search