### PR TITLE
allow slug after ID in oembed project url

### DIFF
--- a/documentcloud/documents/models/document.py
+++ b/documentcloud/documents/models/document.py
@@ -33,8 +33,6 @@ from documentcloud.documents.querysets import DocumentQuerySet
 
 logger = logging.getLogger(__name__)
 
-# pylint:disable = too-many-lines
-
 
 class Document(models.Model):
     """A document uploaded to DocumentCloud"""

--- a/documentcloud/oembed/tests/test_views.py
+++ b/documentcloud/oembed/tests/test_views.py
@@ -10,6 +10,8 @@ import pytest
 # DocumentCloud
 from documentcloud.oembed.oembed import OEmbed
 from documentcloud.oembed.registry import register
+from documentcloud.projects.oembed import ProjectOEmbed
+from documentcloud.projects.tests.factories import ProjectFactory
 
 
 @register
@@ -79,3 +81,23 @@ class TestOEmbedView:
         """Test an oembed call with a non-matching URL"""
         response = client.get("/api/oembed/", {"url": "https://www.example.com/foo/"})
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db()
+class TestProjectOEmbedView:
+
+    @pytest.mark.parametrize("title", ["Test", "123-Test", "Test-456", "789-Test-123"])
+    @pytest.mark.parametrize("url_t", ["{pk}", "{slug}-{pk}", "{pk}-{slug}"])
+    def test(self, client, title, url_t):
+        """Test project oembed view"""
+
+        proj = ProjectFactory.create(title=title)
+        url = "https://www.documentcloud.org/projects/" + url_t.format(
+            pk=proj.pk, slug=proj.slug
+        )
+        response = client.get(
+            "/api/oembed/",
+            {"url": url},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["title"] == proj.title

--- a/documentcloud/oembed/tests/test_views.py
+++ b/documentcloud/oembed/tests/test_views.py
@@ -10,7 +10,6 @@ import pytest
 # DocumentCloud
 from documentcloud.oembed.oembed import OEmbed
 from documentcloud.oembed.registry import register
-from documentcloud.projects.oembed import ProjectOEmbed
 from documentcloud.projects.tests.factories import ProjectFactory
 
 

--- a/documentcloud/projects/oembed.py
+++ b/documentcloud/projects/oembed.py
@@ -20,7 +20,8 @@ class ProjectOEmbed(RichOEmbed):
     patterns = [
         # manager url
         re.compile(
-            rf"^{DOCCLOUD_URL_REGEX}/projects/(?P<full>(?P<proj_pk>[0-9]+)[\w-]*)(/|\?|$)"
+            rf"^{DOCCLOUD_URL_REGEX}/projects/"
+            rf"(?P<full>(?P<proj_pk>[0-9]+)[\w-]*)(/|\?|$)"
         ),
         re.compile(
             rf"^{DOCCLOUD_URL_REGEX}/projects/[\w-]*?(?P<proj_pk>[0-9]+)(/|\?|$)"

--- a/documentcloud/projects/oembed.py
+++ b/documentcloud/projects/oembed.py
@@ -1,5 +1,6 @@
 # Django
 from django.conf import settings
+from django.http.response import Http404
 from django.template.loader import get_template
 from rest_framework.generics import get_object_or_404
 
@@ -19,7 +20,10 @@ class ProjectOEmbed(RichOEmbed):
     patterns = [
         # manager url
         re.compile(
-            rf"^{DOCCLOUD_URL_REGEX}/projects/[\w-]*?(?P<proj_pk>[0-9]+)[\w-]*(/|\?|$)"
+            rf"^{DOCCLOUD_URL_REGEX}/projects/(?P<full>(?P<proj_pk>[0-9]+)[\w-]*)(/|\?|$)"
+        ),
+        re.compile(
+            rf"^{DOCCLOUD_URL_REGEX}/projects/[\w-]*?(?P<proj_pk>[0-9]+)(/|\?|$)"
         ),
         # api url
         re.compile(
@@ -31,9 +35,24 @@ class ProjectOEmbed(RichOEmbed):
     height = 500
 
     def response(self, request, query, max_width=None, max_height=None, **kwargs):
-        project = get_object_or_404(
-            Project.objects.get_viewable(request.user), pk=kwargs["proj_pk"]
-        )
+        try:
+            project = get_object_or_404(
+                Project.objects.get_viewable(request.user), pk=kwargs["proj_pk"]
+            )
+        except Http404:
+            # if we fail to find it and it is using the first regex, try re-parsing
+            # with the second regex
+            if "full" in kwargs:
+                match = re.match(r"[\w-]*?(?P<proj_pk>[0-9]+)$", kwargs["full"])
+                if match:
+                    project = get_object_or_404(
+                        Project.objects.get_viewable(request.user),
+                        pk=match.group("proj_pk"),
+                    )
+                else:
+                    raise
+            else:
+                raise
 
         if max_width and max_width < self.width:
             width = max_width

--- a/documentcloud/projects/oembed.py
+++ b/documentcloud/projects/oembed.py
@@ -19,7 +19,7 @@ class ProjectOEmbed(RichOEmbed):
     patterns = [
         # manager url
         re.compile(
-            rf"^{DOCCLOUD_URL_REGEX}/projects/[\w-]*?(?P<proj_pk>[0-9]+)(/|\?|$)"
+            rf"^{DOCCLOUD_URL_REGEX}/projects/[\w-]*?(?P<proj_pk>[0-9]+)[\w-]*(/|\?|$)"
         ),
         # api url
         re.compile(


### PR DESCRIPTION
This addresses #308 

Previously, the slug was before the ID.  I changed it to accept the slug either before or after the ID.