### PR TITLE
Set note embeds to fixed height by default

### DIFF
--- a/documentcloud/documents/oembed.py
+++ b/documentcloud/documents/oembed.py
@@ -166,7 +166,7 @@ class NoteOEmbed(RichOEmbed):
         context = {
             "src": src,
             "title": note.title,
-            "style": self.get_style(document, note, max_width, max_height),
+            "style": self.get_style(max_width, max_height),
             "width": note_width,
             "height": note_height,
             "resize_script": RESIZE_SCRIPT,
@@ -183,13 +183,11 @@ class NoteOEmbed(RichOEmbed):
 
         return (note_width, note_height)
 
-    def get_style(self, document, note, max_width=None, max_height=None):
-
-        note_width, note_height = self.get_dimensions(document, note)
+    def get_style(self, max_width=None, max_height=None):
 
         style = (
-            f"border: 1px solid #d8dee2; border-radius: 0.5rem; width: 100%;"
-            f" height: 100%; aspect-ratio: {note_width} / {note_height};"
+            "border: 1px solid #d8dee2; border-radius: 0.5rem;"
+            " width: 100%; height: 300px;"
         )
         if max_width:
             style += f" max-width: {max_width}px;"

--- a/documentcloud/documents/tests/test_oembed.py
+++ b/documentcloud/documents/tests/test_oembed.py
@@ -354,9 +354,6 @@ class TestNoteOEmbed:
         response = self.note_oembed.response(
             request, query, max_width=600, max_height=None, doc_pk=123, pk=456
         )
-        note_width, note_height = self.note_oembed.get_dimensions(
-            self.document, self.note
-        )
 
         # Check response properties
         assert response["version"] == "1.0"
@@ -370,10 +367,9 @@ class TestNoteOEmbed:
             "?embed=1&amp;responsive=1"
         ) in response["html"]
         assert 'title="Test Note (Hosted by DocumentCloud)"' in response["html"]
-        assert f'width="{note_width}" height="{note_height}"' in response["html"]
         assert (
-            f"border: 1px solid #d8dee2; border-radius: 0.5rem; width: 100%;"
-            f" height: 100%; aspect-ratio: {note_width} / {note_height};"
+            "border: 1px solid #d8dee2; border-radius: 0.5rem;"
+            " width: 100%; height: 300px;"
         ) in response["html"]
         assert 'sandbox="allow-scripts allow-same-origin' in response["html"]
 


### PR DESCRIPTION
This ensures notes are a readable size regardless of the resizing script.