### PR TITLE
Try checking if table already exists and no-op if it does for addons

### DIFF
--- a/documentcloud/users/migrations/0013_user_active_addons.py
+++ b/documentcloud/users/migrations/0013_user_active_addons.py
@@ -1,21 +1,36 @@
 from django.db import migrations, models
 
-class Migration(migrations.Migration):
 
+class Migration(migrations.Migration):
     dependencies = [
         ("users", "0001_initial_squashed_0010_user_bio_alter_user_email_alter_user_username"),
         ("users", "0007_auto_20211102_1707"),
     ]
-
     operations = [
-        migrations.AddField(
-            model_name="user",
-            name="active_addons",
-            field=models.ManyToManyField(
-                help_text="Add-Ons shown for this user",
-                related_name="users",
-                to="addons.addon",
-                verbose_name="active add-ons",
-            ),
-        ),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="user",
+                    name="active_addons",
+                    field=models.ManyToManyField(
+                        help_text="Add-Ons shown for this user",
+                        related_name="users",
+                        to="addons.addon",
+                        verbose_name="active add-ons",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                        CREATE TABLE IF NOT EXISTS users_user_active_addons (
+                            id serial NOT NULL PRIMARY KEY,
+                            user_id integer NOT NULL REFERENCES users_user(id) DEFERRABLE INITIALLY DEFERRED,
+                            addon_id bigint NOT NULL REFERENCES addons_addon(id) DEFERRABLE INITIALLY DEFERRED
+                        )
+                    """,
+                    reverse_sql="DROP TABLE IF EXISTS users_user_active_addons",
+                ),
+            ],
+        )
     ]


### PR DESCRIPTION
To fix tests, I had to squash some migrations for the CIText fields and also fix circular migrations. This means the the 13th migration has to run on fresh databases like tests, but fails on staging and production because the table already exists. This will try to check if the table already exists and if it does, no-op it 