### PR TITLE
Fixes setting user on third party Add-Ons for new developers

### DIFF
--- a/documentcloud/addons/signals.py
+++ b/documentcloud/addons/signals.py
@@ -20,7 +20,7 @@ def update_github_account(user, data, **_kwargs):
     """Save the GitHub account information when a user is updated"""
     logger.info("Update GitHub Account information")
     for acct in data.get("social_accounts", []):
-        if acct["provider"] != "github_app":
+        if acct["provider"] != "github":
             continue
         if acct["tokens"]:
             token = acct["tokens"][0]["token"]


### PR DESCRIPTION
Alex G. from Datasette couldn't link the Github app to his user account on DocumentCloud to test an Add-On. The user was listed as "None" in the admin panel for the linked Add-On and I couldn't update in the panel, had to do so in the Django shell. I saw that one other user had the same problem. 

documentcloud/addons/signals.py line 23
if acct["provider"] != "github_app":
    continue
https://github.com/MuckRock/documentcloud/blob/f3b387c74c42a644bc4df255ef4dcb7e3fa1a96b/documentcloud/addons/signals.py#L23

DocumentCloud's update_github_account signal handler filters incoming Squarelet user_update payloads for social accounts with provider == "github_app" and uses them to set GitHubAccount.user. On January 10, 2025, a Squarelet migration renamed that provider from "github_app" to "github", so the filter never matches anymore. The handler silently skips every GitHub social account, GitHubAccount.user is never populated for new third-party users, and AddOn.user (which reads through github_account.user) returns None.

Migration that broke this: 
https://github.com/MuckRock/squarelet/commit/e7ff9eba9418a6aec6afc705b640b0bd2a3b1c9b