### PR TITLE
Specify Python 3.10 in lambda yml only

### DIFF
--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -10,6 +10,10 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Show deployment info
         run: |
           echo "Deployment environment: ${{ github.event.deployment.environment }}"


### PR DESCRIPTION
Now that we use 3.12 in Docker and 3.10 in lambda workflows an issue arises when trying to run the workflow without explicitly specifying it 