### PR TITLE
Filter by message

### DIFF
--- a/documentcloud/addons/tests/test_views.py
+++ b/documentcloud/addons/tests/test_views.py
@@ -350,3 +350,26 @@ class TestAddOnEventAPI:
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["results"] == []
+
+    def test_filter_message(self, client):
+        """Filter runs by message"""
+        user = UserFactory()
+        matching_run = AddOnRunFactory(user=user, message="data changed")
+        AddOnRunFactory(user=user, message="no changes detected")
+        AddOnRunFactory(user=user, message="")
+        client.force_authenticate(user=user)
+        response = client.get("/api/addon_runs/", {"message": "data changed"})
+        assert response.status_code == status.HTTP_200_OK
+        uuids = [r["uuid"] for r in response.json()["results"]]
+        assert uuids == [str(matching_run.uuid)]
+
+    def test_filter_message_absent_is_noop(self, client):
+        """Omitting the message filter returns all viewable runs"""
+        user = UserFactory()
+        AddOnRunFactory(user=user, message="data changed")
+        AddOnRunFactory(user=user, message="no changes detected")
+        AddOnRunFactory(user=user, message="")
+        client.force_authenticate(user=user)
+        response = client.get("/api/addon_runs/")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["results"]) == 3

--- a/documentcloud/addons/views.py
+++ b/documentcloud/addons/views.py
@@ -743,6 +743,7 @@ class AddOnRunViewSet(FlexFieldsModelViewSet):
         site = django_filters.CharFilter(
             field_name="event__parameters__site",
             lookup_expr="exact",
+            label="Site",
             help_text="Filter runs by the `site` value in the event's parameters.",
         )
         message = django_filters.CharFilter(
@@ -984,6 +985,7 @@ class AddOnEventViewSet(FlexFieldsModelViewSet):
         site = django_filters.CharFilter(
             field_name="parameters__site",
             lookup_expr="exact",
+            label="Site",
             help_text="Filter events by the `site` value in their parameters.",
         )
 

--- a/documentcloud/addons/views.py
+++ b/documentcloud/addons/views.py
@@ -745,6 +745,12 @@ class AddOnRunViewSet(FlexFieldsModelViewSet):
             lookup_expr="exact",
             help_text="Filter runs by the `site` value in the event's parameters.",
         )
+        message = django_filters.CharFilter(
+            field_name="message",
+            lookup_expr="exact",
+            label="Message",
+            help_text="Filter runs by their progress message.",
+        )
 
         class Meta:
             model = AddOnRun


### PR DESCRIPTION
Adds a filter so we can match (exact only for now) by message status, should help with Klaxon front-end. I also noticed the filter for site had an [invalid name]: warning when you visit it on via the browser because Django can't derive a name automatically for them, so the labels should fix that. 