### PR TITLE
Site lookup can be case-insensitive

### DIFF
--- a/documentcloud/addons/views.py
+++ b/documentcloud/addons/views.py
@@ -742,7 +742,7 @@ class AddOnRunViewSet(FlexFieldsModelViewSet):
         dismissed = django_filters.BooleanFilter(help_text="Was this run dismissed?")
         site = django_filters.CharFilter(
             field_name="event__parameters__site",
-            lookup_expr="exact",
+            lookup_expr="iexact",
             label="Site",
             help_text="Filter runs by the `site` value in the event's parameters.",
         )

--- a/documentcloud/addons/views.py
+++ b/documentcloud/addons/views.py
@@ -984,7 +984,7 @@ class AddOnEventViewSet(FlexFieldsModelViewSet):
         )
         site = django_filters.CharFilter(
             field_name="parameters__site",
-            lookup_expr="exact",
+            lookup_expr="iexact",
             label="Site",
             help_text="Filter events by the `site` value in their parameters.",
         )


### PR DESCRIPTION
One-letter change to make the `site` parameter for add-on runs case-insensitive.