### PR TITLE
Add better parsing of email addresses and add tests for mailgun

### DIFF
--- a/documentcloud/core/tests.py
+++ b/documentcloud/core/tests.py
@@ -2,12 +2,21 @@
 from django.contrib.flatpages.models import FlatPage
 from django.contrib.sites.models import Site
 from django.db import transaction
+from django.test import TestCase
+from django.urls import reverse
 
 # Standard Library
+import hashlib
+import hmac
+import time
+import uuid
 from unittest import mock
 
 # Third Party
 import pytest
+
+# DocumentCloud
+from documentcloud.users.tests.factories import UserFactory
 
 
 def run_commit_hooks():
@@ -35,3 +44,52 @@ def test_flatpage_markdown(client):
     flatpage.save()
     response = client.get("/pages/about/")
     assert b'<h2 id="now-h2">Now H2</h2>' in response.content
+
+
+class TestMailgunView(TestCase):
+    """Tests for the mailgun email upload view"""
+
+    def sign(self, data):
+        """Add a valid mailgun signature to POST data"""
+        token = "testtoken"
+        timestamp = int(time.time())
+        signature = hmac.new(
+            key="".encode("utf8"),
+            msg=f"{timestamp}{token}".encode("utf8"),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
+        data["token"] = token
+        data["timestamp"] = timestamp
+        data["signature"] = signature
+
+    def mailgun_post(self, to_addr, attachments="[]", sign=True):
+        data = {"To": to_addr, "attachments": attachments}
+        if sign:
+            self.sign(data)
+        return self.client.post(reverse("mailgun"), data)
+
+    def test_valid_mailkey(self):
+        user = UserFactory(mailkey=uuid.uuid4())
+        response = self.mailgun_post(f"{user.mailkey}@uploads.documentcloud.org")
+        assert response.status_code == 200
+
+    def test_quoted_to_header(self):
+        """Mailgun sometimes sends To as '"mailkey@domain" <mailkey@domain>'"""
+        user = UserFactory(mailkey=uuid.uuid4())
+        to_addr = (
+            f'"{user.mailkey}@uploads.documentcloud.org"'
+            f" <{user.mailkey}@uploads.documentcloud.org>"
+        )
+        response = self.mailgun_post(to_addr)
+        assert response.status_code == 200
+
+    def test_unknown_mailkey(self):
+        response = self.mailgun_post("doesnotexist@uploads.documentcloud.org")
+        assert response.status_code == 200
+
+    def test_invalid_signature(self):
+        user = UserFactory(mailkey=uuid.uuid4())
+        response = self.mailgun_post(
+            f"{user.mailkey}@uploads.documentcloud.org", sign=False
+        )
+        assert response.status_code == 403

--- a/documentcloud/core/views.py
+++ b/documentcloud/core/views.py
@@ -1,6 +1,7 @@
 # Django
 from django.conf import settings
 from django.contrib.auth import logout
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.http.response import (
     Http404,
@@ -22,6 +23,7 @@ import json
 import logging
 import os
 import time
+from email.utils import parseaddr
 from urllib.parse import urlencode
 
 # DocumentCloud
@@ -91,11 +93,12 @@ def mailgun(request):
         return HttpResponseForbidden()
 
     email = request.POST["To"]
-    mailkey = email.split("@", 1)[0]
+    _, addr = parseaddr(email)
+    mailkey = addr.split("@", 1)[0]
     logger.info("[MAILKEY] received mailkey %s", mailkey)
     try:
         user = User.objects.get(mailkey=mailkey)
-    except User.DoesNotExist:
+    except (User.DoesNotExist, ValidationError):
         logger.warning("[MAILKEY] mailkey %s user not found", mailkey)
         return HttpResponse("OK")
 


### PR DESCRIPTION
Our previous logic took everything before the first @, which in some cases would include a leading quotation mark " (depending I guess on the email server sending it) like:

""uuid@uploads.documentcloud.org" <uuid@uploads.documentcloud.org>"
in the To field. This PR moves us to use a more robust and built in email parsing [email.utils.parseaddr](https://docs.python.org/3/library/email.utils.html#email.utils.parseaddr) which will handle those leading quotes automatically, as well as < and other possible symbols. It also automatically rejects malformed inputs for safety. 

This PR also raises ValidationErrors in case parseaddr somehow doesn't catch anything and adds some tests for mailgun since there were none. I had Claude write the tests because they are boilerplate. 

Closes #406 