### PR TITLE
Pin local Python services to linux/amd64

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -7,6 +7,7 @@ volumes:
 
 services:
   documentcloud_django: &django
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ./compose/local/django/Dockerfile


### PR DESCRIPTION
## Problem

Loading `documentcloud/documents/processing/info_and_image/libpdfium.so2` fails inside the local Docker containers on Apple Silicon, with a misleading "unable to access the file" error. The file is present — the real issue is an architecture mismatch:

- The vendored `libpdfium.so2` is an **x86-64 ELF** binary.
- On Apple Silicon, Docker runs the Python containers natively as **arm64 (aarch64)**, so `ctypes.cdll.LoadLibrary` cannot load the wrong-architecture library.

## Fix

Pin the Django/Celery services to `linux/amd64` via the shared `&django` anchor in `local.yml`. This covers `documentcloud_django`, `documentcloud_celeryworker`, and `documentcloud_celerybeat`, matching the vendored binary and the production/Lambda x86-64 environment.

## Verification

After rebuilding and recreating the services:

- `uname -m` inside the container now reports `x86_64` (was `aarch64`).
- `cdll.LoadLibrary('.../libpdfium.so2')` succeeds.

## Tradeoff

These three services now run under QEMU emulation on Apple Silicon, so they will be somewhat slower. Other services (postgres, redis, solr, minio) are unchanged and stay native arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)