### PR TITLE
If a site is detected in params, add it to the disable email

### DIFF
--- a/documentcloud/templates/addons/email/base_disabled.html
+++ b/documentcloud/templates/addons/email/base_disabled.html
@@ -1,14 +1,24 @@
 {% extends "core/email/base.html" %}
-
 {% block body %}
-
   <p>
     Your scheduled run of the Add-On {{ run.addon.name }} has not run
     succesfully the last five times it was ran.  We have therefore disabled the
     scheduled run.  <a href="{{ settings.DOCCLOUD_URL }}/add-ons/{{ run.addon.repository }}/{{ run.event.id }}/">View the scheduled run details here.</a>
   </p>
+  {% if run.event.parameters.site %}
+  <p>
+    This scheduled run was monitoring: <a href="{{ run.event.parameters.site }}">{{ run.event.parameters.site }}</a>
+  </p>
+  {% endif %}
+  <p>
+    You may debug the issue
+    <a href="https://github.com/{{ run.addon.repository }}/actions/runs/{{ run.run_id }}/">
+      using the GitHub logs.
+    </a>  Once fixed, you may re-enable it from the Add-On menu on
+    DocumentCloud.  If you need assistance debugging, please ask on
+    <a href="https://www.muckrock.com/slack/">our Slack channel.</a>
+  </p>
   <p>
     {{ footer_content|urlize }}
   </p>
-
 {% endblock body %}


### PR DESCRIPTION
<img width="1506" height="659" alt="image" src="https://github.com/user-attachments/assets/eb64be0a-fa3d-4d9b-9377-c4da5746a520" />

Would close https://github.com/MuckRock/Klaxon/issues/27