### PR TITLE
Prevent needlessly enqueing Celery tasks from update config

### DIFF
--- a/documentcloud/addons/views.py
+++ b/documentcloud/addons/views.py
@@ -429,8 +429,12 @@ class AddOnViewSet(viewsets.ModelViewSet):
     @action(detail=False, methods=["post"], permission_classes=[AllowAny])
     def update_config(self, request):
         name = request.data.get("repository")
-        if name:
+        # If the name doesn't match an existing repo to an Add-On,
+        # don't needlessly enqueue a celery task only for it to no-op
+        if name and AddOn.objects.filter(repository=name, removed=False).exists():
             update_config.delay(name)
+        else:
+            logger.warning("[ADDON] update_config no match for repository=%s", name)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     class Filter(django_filters.FilterSet):


### PR DESCRIPTION
If the repo doesn't match anything, catch it right away instead of even passing it onto celery to no-op. Already on staging and confirmed to work. Now just merging from staging to master 