### PR TITLE
Fix DMARC misalignment

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -135,6 +135,9 @@ ADMIN_URL = env("DJANGO_ADMIN_URL")
 INSTALLED_APPS += ["anymail", "djcelery_email"]  # noqa F405
 CELERY_EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 EMAIL_BACKEND = "djcelery_email.backends.CeleryEmailBackend"
+# Preserve Anymail attributes when it gets to Celery
+CELERY_EMAIL_MESSAGE_EXTRA_ATTRIBUTES = ["esp_extra", "envelope_sender"]
+
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 ANYMAIL = {
     "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -136,7 +136,7 @@ INSTALLED_APPS += ["anymail", "djcelery_email"]  # noqa F405
 CELERY_EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 EMAIL_BACKEND = "djcelery_email.backends.CeleryEmailBackend"
 # Preserve Anymail attributes when it gets to Celery
-CELERY_EMAIL_MESSAGE_EXTRA_ATTRIBUTES = ["esp_extra", "envelope_sender"]
+CELERY_EMAIL_MESSAGE_EXTRA_ATTRIBUTES = ["envelope_sender"]
 
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 ANYMAIL = {


### PR DESCRIPTION
<img width="1624" height="336" alt="image" src="https://github.com/user-attachments/assets/c8e15aab-4ea5-4a4f-ba4d-428fb032e804" />


<img width="1624" height="181" alt="image" src="https://github.com/user-attachments/assets/28c224dd-f3ea-478f-8292-6afb0fe2d085" />

Production sends emails asynchronously via a Celery task. The EMAIL_BACKEND is djcelery_email.backends.CeleryEmailBackend, which serializes the message to a dict, ships it to a Celery worker, and only there hands it to CELERY_EMAIL_BACKEND (the Anymail Mailgun backend). django-celery-email's email_to_dict only carries standard Django message fields plus any attributes listed in CELERY_EMAIL_MESSAGE_EXTRA_ATTRIBUTES. Anymail-specific attributes like envelope_sender are not in the default set, so they were dropped in serialization. By the time the worker's Mailgun backend ran, there was no per-message override left, and it fell back to MAILGUN_SENDER_DOMAIN which is mg.documentcloud.org 